### PR TITLE
ci: update GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,6 +1,7 @@
 name: Backend CI
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "backend/**"

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,7 +1,6 @@
 name: Backend CI
 
 on:
-  workflow_dispatch:
   pull_request:
     paths:
       - "backend/**"

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: '3.13'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "backend/pyproject.toml"

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -48,15 +48,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "backend/pyproject.toml"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR body references an issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const body = context.payload.pull_request.body || '';
@@ -36,7 +36,7 @@ jobs:
     needs: check-issue-reference
     steps:
       - name: Verify linked issue(s) have status:approved label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR has exactly one type:* label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Closes #43

### Summary
- Bump four GitHub Actions across `api-ci.yml` and `pr-check.yml` from Node 20 majors to their latest stable majors targeting Node 24
- Resolves the deprecation warnings observed in Backend CI run #30593029457

### Changes
| File | Change |
|------|--------|
| `.github/workflows/api-ci.yml` | `actions/checkout@v4`→`v7`, `actions/setup-python@v5`→`v7`, `astral-sh/setup-uv@v5`→`v7` |
| `.github/workflows/pr-check.yml` | `actions/github-script@v7`→`v9` (3 occurrences) |

### Version evidence
| Action | Old | New | `runs.using` | Source |
|--------|-----|-----|---------------|--------|
| `actions/checkout` | `@v4` | `@v7` | `node24` | tag `v7.0.1` → floating `v7` |
| `actions/setup-python` | `@v5` | `@v7` | `node24` | tag `v7.0.0` → floating `v7` |
| `astral-sh/setup-uv` | `@v5` | `@v7` | `node24` | tag `v7.6.0` → floating `v7` |
| `actions/github-script` | `@v7` | `@v9` | `node24` | tag `v9.0.0` → floating `v9` |

### Test Plan
- [x] YAML syntax validated with `python3 -c 'import yaml, sys; yaml.safe_load(open(sys.argv[1]))'` for both workflows
- [x] Existing inputs, caching, permissions, concurrency, services, and commands preserved (no structural changes)
- [x] Manual Backend CI run [#30593503282](https://github.com/jonasotoaguilar/eventcommerce/actions/runs/30593503282) passed in 49s with `checkout@v7`, `setup-python@v7`, `setup-uv@v7` — zero Node 20 deprecation annotations