### PR TITLE
test(checkout): add structural regression coverage

### DIFF
--- a/backend/app/tests/test_checkout_structural_regressions.py
+++ b/backend/app/tests/test_checkout_structural_regressions.py
@@ -1,0 +1,108 @@
+"""Structural regression tests for checkout end-to-end tasks 2.8, 4.1, 4.2.
+
+Makes the previously static-verification-only TDD rows executable:
+
+- 2.8: ADR 0005 records status "Accepted (current implementation)".
+- 4.1: no application (non-test) Python source references the obsolete
+  module path ``app.modules.orders.infrastructure.repositories.sqlalchemy_repository``.
+- 4.2: the obsolete stub file ``backend/app/modules/orders/infrastructure/
+  repositories/sqlalchemy_repository.py`` is absent while the live
+  repository module remains present.
+
+All paths resolve from ``__file__`` so the file also runs in disposable
+worktree snapshots (pre-S2 ``6018493``, pre-S4 ``505c225``) without
+environment or CWD assumptions.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ADR_0005_PATH = (
+    REPO_ROOT / "docs" / "adr" / "0005-use-deterministic-simulated-payments.md"
+)
+APP_DIR = REPO_ROOT / "backend" / "app"
+DEAD_STUB_PATH = (
+    APP_DIR
+    / "modules"
+    / "orders"
+    / "infrastructure"
+    / "repositories"
+    / "sqlalchemy_repository.py"
+)
+LIVE_REPO_PATH = (
+    APP_DIR / "modules" / "orders" / "infrastructure" / "sqlalchemy_repository.py"
+)
+
+DEAD_MODULE_TOKEN = "repositories.sqlalchemy_repository"
+LIVE_MODULE_TOKEN = "app.modules.orders.infrastructure.sqlalchemy_repository"
+
+EXPECTED_ADR_STATUS = "Accepted (current implementation)"
+MIN_SCANNED_FILES = 50
+
+
+def _production_python_files() -> list[Path]:
+    """All ``.py`` files under ``backend/app`` excluding test directories."""
+    return sorted(
+        py_file for py_file in APP_DIR.rglob("*.py") if "tests" not in py_file.parts
+    )
+
+
+def test_adr_0005_status_is_accepted_current_implementation() -> None:
+    """Task 2.8: ADR 0005 records the accepted current implementation status."""
+    text = ADR_0005_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    heading_indexes = [
+        index for index, line in enumerate(lines) if line.strip() == "## Status"
+    ]
+    assert len(heading_indexes) == 1, (
+        f"expected exactly one '## Status' heading in {ADR_0005_PATH}"
+    )
+    status = next(
+        (line.strip() for line in lines[heading_indexes[0] + 1 :] if line.strip()),
+        None,
+    )
+    assert status == EXPECTED_ADR_STATUS, (
+        f"ADR 0005 status is {status!r}; expected {EXPECTED_ADR_STATUS!r}"
+    )
+
+
+def test_no_production_python_references_dead_module_path() -> None:
+    """Task 4.1: nothing under the application imports the obsolete module."""
+    offenders: list[Path] = []
+    scanned = 0
+    for py_file in _production_python_files():
+        scanned += 1
+        source = py_file.read_text(encoding="utf-8", errors="replace")
+        if DEAD_MODULE_TOKEN in source:
+            offenders.append(py_file)
+    assert scanned >= MIN_SCANNED_FILES, (
+        f"production scan covered only {scanned} files; "
+        "repo path resolution is likely broken"
+    )
+    assert offenders == [], (
+        f"obsolete module path {DEAD_MODULE_TOKEN!r} referenced by: "
+        + ", ".join(str(py_file) for py_file in offenders)
+    )
+
+
+def test_positive_control_live_module_is_referenced() -> None:
+    """The scanner can detect module-path references (anti-ghost guard)."""
+    referencing = [
+        py_file
+        for py_file in _production_python_files()
+        if LIVE_MODULE_TOKEN in py_file.read_text(encoding="utf-8", errors="replace")
+    ]
+    assert len(referencing) >= 1, (
+        f"live module path {LIVE_MODULE_TOKEN!r} referenced by no "
+        "production file; the 4.1 scan would not detect real references"
+    )
+
+
+def test_dead_stub_file_is_absent() -> None:
+    """Task 4.2: the obsolete stub file was deleted and stays deleted."""
+    assert not DEAD_STUB_PATH.exists(), f"obsolete stub still present: {DEAD_STUB_PATH}"
+
+
+def test_live_repository_file_is_present() -> None:
+    """Companion to the stub-absence test: the live module must survive."""
+    assert LIVE_REPO_PATH.is_file(), f"live repository module missing: {LIVE_REPO_PATH}"

--- a/openspec/changes/checkout-end-to-end/verify-report.md
+++ b/openspec/changes/checkout-end-to-end/verify-report.md
@@ -1,0 +1,202 @@
+```yaml
+schema: gentle-ai.verify-result/v1
+evidence_revision: sha256:3b68bfdff57874b3f41487223dc67bfa7b358a26db88f8b9890b9a28f1b6497f
+verdict: fail
+blockers: 1
+critical_findings: 1
+requirements: 7/7
+scenarios: 12/12
+test_command: uv run python -m pytest -q
+test_exit_code: 0
+test_output_hash: sha256:58891bfffd32f8b1cfacf2654439c654ac0f1549548ceac70e8df0b062b47d7d
+build_command: uv run pyrefly check
+build_exit_code: 0
+build_output_hash: sha256:f9c423e5173017218922360450fdc085e33b2e0483660820aefccb6fa007ec55
+```
+
+## Verification Report
+
+**Change**: `checkout-end-to-end`
+**Version**: N/A
+**Mode**: Strict TDD
+**Artifact persistence**: Hybrid — OpenSpec file plus Engram topic `sdd/checkout-end-to-end/verify-report`.
+**Repository state**: `verify/checkout-end-to-end-tdd-evidence` at `e5c226196a4fbdf0c4cb9616863635a77052c5da` (current `main`); no production source changes. The only pre-report worktree entry was the authorized verification report artifact.
+**Native runtime authority**: attempt ordinal 11, revision `sha256:02a7804f56c7692156a14b87b868e4ee2ab42e6df78e5010bb727276eac44d79`, still `running` and retained by the orchestrator; this verifier did not acquire or settle it.
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 38 |
+| Tasks complete | 38 |
+| Tasks incomplete | 0 |
+| Requirements total | 7 |
+| Requirements compliant | 7 |
+| Scenarios total | 12 |
+| Scenarios compliant | 12 |
+
+The retrieved OpenSpec tasks contain 38 checked items and 0 unchecked items. The retrieved checkout spec contains 7 requirements and 12 scenarios. No incomplete task blocks runtime verification.
+
+### Build & Tests Execution
+**Tests**: ✅ 246 passed / 0 failed / 1 warning
+- Command: `uv run python -m pytest -q` (working directory: `backend/`)
+- Exit code: `0`
+- Exact combined-output hash: `sha256:58891bfffd32f8b1cfacf2654439c654ac0f1549548ceac70e8df0b062b47d7d`
+- Runtime summary: `246 passed, 1 warning in 11.24s`
+- Warning: Starlette deprecates the `httpx` integration used by `TestClient`; it did not fail the suite.
+
+**Linter**: ✅ Ruff check passed
+| Command | Exit | Output hash | Result |
+|---------|------|-------------|--------|
+| `uv run ruff check .` | 0 | `sha256:82b3e6a6c090a57601d22943bd23fca9218d1031dbe5a7b754092f9a156b4f18` | `All checks passed!` |
+
+**Formatting**: ✅ Ruff format check passed
+| Command | Exit | Output hash | Result |
+|---------|------|-------------|--------|
+| `uv run ruff format --check .` | 0 | `sha256:4efb24614e1989f8459fcf5942e007e1505a707a6613f549c57c29d48cebc4eb` | `193 files already formatted` |
+
+**Build/type check**: ✅ Pyrefly passed
+- Command: `uv run pyrefly check` (working directory: `backend/`)
+- Exit code: `0`
+- Exact combined-output hash: `sha256:f9c423e5173017218922360450fdc085e33b2e0483660820aefccb6fa007ec55`
+- Runtime summary: `0 errors (25 suppressed, 2 warnings not shown)`
+
+**Coverage**: ➖ Skipped — `pytest-cov` is neither importable nor declared in `backend/pyproject.toml`.
+
+### Spec Compliance Matrix
+| Requirement | Scenario | Covering test | Result |
+|-------------|----------|---------------|--------|
+| Checkout Request Validation | Valid request proceeds | `backend/app/tests/modules/checkout/api/test_routes.py > test_accepted_outcome_returns_201_with_response_body` | ✅ COMPLIANT |
+| Checkout Request Validation | Invalid quantity or empty items rejected | `backend/app/tests/modules/checkout/api/test_routes.py > test_validation_errors_return_422` | ✅ COMPLIANT |
+| Synchronous Orchestration and AMQP Independence | Happy path confirms the order | `backend/app/tests/modules/checkout/application/test_checkout.py > test_happy_path_confirms_order_with_reserved_inventory`; `backend/app/tests/modules/checkout/api/test_checkout_e2e.py > test_confirmed_checkout_emits_one_notification_intent` | ✅ COMPLIANT |
+| Single Terminal Transition Ownership | Exactly one terminal transition | `backend/app/tests/modules/checkout/application/test_checkout.py > test_happy_path_confirms_exactly_once`, `test_payment_declined_cancels_exactly_once`, `test_insufficient_stock_cancels_exactly_once` | ✅ COMPLIANT |
+| Compensation Paths | Insufficient stock cancels | `backend/app/tests/modules/checkout/application/test_checkout.py > test_insufficient_stock_cancels_without_any_payment`; `backend/app/tests/modules/checkout/api/test_checkout_e2e.py > test_insufficient_stock_cancel_emits_one_notification_intent` | ✅ COMPLIANT |
+| Compensation Paths | Payment declined releases inventory and cancels | `backend/app/tests/modules/checkout/application/test_checkout.py > test_payment_decline_releases_inventory_and_cancels_once`; `backend/app/tests/modules/checkout/api/test_checkout_e2e.py > test_payment_declined_cancel_emits_one_notification_intent` | ✅ COMPLIANT |
+| Deterministic Payment Authorization and Payment Record | Determinism across evaluations | `backend/app/modules/payments/tests/test_payment_policy.py > test_outcome_is_stable_across_1000_evaluations`; `test_first_digest_byte_is_stable_across_1000_evaluations` | ✅ COMPLIANT |
+| Idempotency-Key Contract and Concurrency Isolation | Missing key executes per request | `backend/app/tests/modules/checkout/api/test_checkout_e2e.py > test_two_identical_requests_without_key_create_two_orders` | ✅ COMPLIANT |
+| Idempotency-Key Contract and Concurrency Isolation | Replay returns cached response | `backend/app/tests/modules/checkout/api/test_checkout_e2e.py > test_identical_replay_returns_cached_201_without_reexecution` | ✅ COMPLIANT |
+| Idempotency-Key Contract and Concurrency Isolation | Key reused with differing payload conflicts | `backend/app/tests/modules/checkout/api/test_checkout_e2e.py > test_mismatched_payload_returns_409_and_keeps_first_execution` | ✅ COMPLIANT |
+| Idempotency-Key Contract and Concurrency Isolation | Concurrent duplicates isolate | `backend/app/tests/modules/checkout/api/test_checkout_e2e.py > test_concurrent_duplicates_execute_once_with_identical_response` | ✅ COMPLIANT |
+| Checkout Response, Notification, and Status Mapping | Status and notification mapping | `backend/app/tests/modules/checkout/api/test_routes.py > test_accepted_outcome_returns_201_with_response_body`, `test_conflict_outcome_maps_to_409`, `test_validation_errors_return_422`; `backend/app/tests/modules/checkout/api/test_checkout_e2e.py > test_notification_failure_does_not_roll_back_checkout` | ✅ COMPLIANT |
+
+**Compliance summary**: 12/12 scenarios compliant. The successful persisted payment uses the existing domain status `authorized`; the spec's `approved` wording is treated as the approval outcome, not a separate persisted enum.
+
+### Correctness (Static Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Request validation before side effects | ✅ Implemented | `CheckoutRequest` enforces item, quantity, amount, currency, uniqueness, and visible-ASCII key constraints; route tests verify invalid input is rejected before the use case receives it. |
+| Synchronous orchestration | ✅ Implemented | `Checkout.execute` claims, creates, locks/reserves, authorizes, transitions once, caches, commits, then attempts notification. |
+| Terminal transition ownership | ✅ Implemented | Only `Checkout._confirm_order` / `_cancel_order` call `Order.confirm` / `Order.cancel`; `ProcessOrderInventoryResult` is not imported or invoked by checkout. |
+| Compensation | ✅ Implemented | Insufficient stock cancels without payment; payment rejection persists failure, releases stock, and cancels with the required reason. |
+| Deterministic payment | ✅ Implemented | SHA-256 first-byte policy with Decimal two-place canonicalization and threshold 192; payment use cases persist authorized or declined records. |
+| Durable idempotency | ✅ Implemented | Processed-event claim state, payload hash, response cache, 16 KiB cap, and PostgreSQL advisory lock are covered by passing tests. |
+| HTTP response and notifications | ✅ Implemented | Route maps 201/409/422/500; post-commit notification failure rolls back only its own attempt and does not undo committed commerce. |
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| One transaction for commerce, outbox, and idempotency | ✅ Yes | Repository flushes remain inside the core transaction and the orchestrator commits once before notification. |
+| Durable replay cache and cross-process claim isolation | ✅ Yes | `ProcessedEventStore` uses persisted claim/response fields and `pg_advisory_xact_lock`. |
+| Request-local dependency wiring | ⚠️ Runtime-safe, design deviation | The route binds the request session before resolving the factory, but it uses `checkout_container.session.override(session)`; the design explicitly says checkout uses no global session override. Concurrent duplicate HTTP coverage passed. |
+| Three-state order model and orchestrator ownership | ✅ Yes | No five-state expansion or synchronous `ProcessOrderInventoryResult`; terminal status mutation remains in `Checkout`. |
+| Deterministic Decimal payment math | ✅ Yes | Fixed threshold 192 and pinned vectors match the design. |
+| Post-commit best-effort notification | ✅ Yes | Notification failure is caught after commerce commit and does not roll back terminal commerce. |
+| Observability contract | ⚠️ Partial | Key hashes are eight-character SHA-256 prefixes and raw keys are excluded, but current log messages do not include the design-requested outcome and duration fields. |
+
+### TDD Compliance
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ❌ | The retrieved Engram `sdd/checkout-end-to-end/apply-progress` artifact has no `TDD Cycle Evidence` table, and no OpenSpec apply-progress file exists. |
+| All tasks have tests | ⚠️ | Current diff inventory has 18 executable changed test files and 138 test functions, but the missing per-task table prevents proving a test mapping for every task. |
+| RED confirmed (tests exist) | ❌ | Per-task RED entries cannot be verified without the required table. |
+| GREEN confirmed (tests pass) | ❌ | The complete suite passed, but per-task GREEN claims cannot be cross-referenced without the required table. |
+| Triangulation adequate | ❌ | Per-task triangulation claims cannot be checked without the required table. |
+| Safety Net for modified files | ❌ | Per-task safety-net claims cannot be checked without the required table. |
+
+**TDD Compliance**: 0/6 checks independently verifiable. The maintainer exception is recorded below; it does not fabricate historical cycles or change these evidence results.
+
+### Test Layer Distribution
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 61 | 7 | Pytest; pure Python/domain tests |
+| Integration | 69 | 10 | Pytest, SQLAlchemy, PostgreSQL |
+| E2E/HTTP | 8 | 1 | Pytest, httpx ASGI transport, PostgreSQL |
+| **Total** | **138** | **18 executable test files** | |
+
+All layers used by the changed tests have the required installed/runtime tools. No browser E2E layer is in this backend change.
+
+### Changed File Coverage
+Coverage analysis skipped — no `pytest-cov` tool is available or declared.
+
+### Assertion Quality
+✅ No banned assertion-quality violation was found in the 18 executable changed test files. The audit covered 138 tests and 382 assertions: no tautologies, ghost loops, smoke-only tests, or mock-heavy violations. Seven empty-collection assertions are intentional negative side-effect, ownership, or empty-input checks with behavioral companions. Three static contract tests inspect production declarations (the payment threshold, constructor shape, and ORM columns); they are intentional structural checks, not tautologies or no-op assertions.
+
+### Quality Metrics
+- **Ruff**: ✅ 0 errors; format check passed for 193 files.
+- **Pyrefly**: ✅ 0 errors; command exit 0 (25 suppressed, 2 warnings not shown).
+
+### Maintainer-Approved Historical Strict TDD Evidence Exception
+- **Authority**: explicit maintainer decision recorded in Engram topic `sdd/checkout-end-to-end/tdd-evidence-exception` and supplied for this verification.
+- **Scope**: historical absence of independently verifiable per-task RED/GREEN/Triangulate/Safety Net/Refactor records for this already-completed change only.
+- **Non-waivers**: runtime correctness, requirements/scenario traceability, task completeness, current tests, Ruff lint, formatting, Pyrefly typing, assertion-quality review, and Git/source cleanliness remain required and were checked.
+- **Integrity**: no TDD cycles were reconstructed or fabricated. The current report preserves the missing-evidence finding.
+- **Skill disposition**: the loaded `sdd-verify` and `strict-tdd-verify` instructions define the missing `TDD Cycle Evidence` table as a CRITICAL failure and define no maintainer exception/waiver path. Therefore this exception is recorded as historical risk, but it cannot make this report archival-ready or convert the verdict to PASS.
+
+### Issues Found
+**CRITICAL**:
+1. The mandatory Strict TDD `TDD Cycle Evidence` table is absent from the authoritative apply-progress artifact. Under the loaded skill, RED/GREEN/triangulation/safety-net evidence is not independently verifiable per task; the maintainer exception cannot waive that rule because no waiver semantics are defined.
+
+**WARNING**:
+1. Request-local DI uses a mutable provider override, contrary to the design's explicit no-global-session-override wording; concurrency tests passed, so this is a coherence warning rather than a runtime failure.
+2. Design observability requests structured outcome and duration fields; current logs omit those fields while excluding raw keys and retaining key-hash prefixes.
+3. The spec says persisted payment `approved` while the established domain status is `authorized`; behavior is semantically consistent but the wording should be clarified in a future spec revision.
+4. Pytest emitted one Starlette/httpx deprecation warning; Pyrefly reported two warnings not shown. Neither caused a command failure.
+
+**SUGGESTION**:
+1. Preserve the maintainer exception as historical risk and do not attempt to recreate missing cycle records; any future work should produce per-task evidence at apply time.
+2. Add `pytest-cov` only if changed-file coverage becomes a project requirement.
+
+### Runtime Settlement Evidence
+```yaml
+outcome: verification_checks_passed_archival_gate_blocked
+diagnosis: strict_tdd_process_evidence_missing_and_no_skill_waiver
+harness_disposition: reused_existing_backend_test_environment; active_attempt_11_retained_by_orchestrator; verifier_did_not_settle
+cleanup_evidence: no production source changes; pre-report git diff check clean; no external harness or process was launched by this verifier
+process_evidence: attempt=11; attempt_revision=sha256:02a7804f56c7692156a14b87b868e4ee2ab42e6df78e5010bb727276eac44d79; attempt_state=running; tests=246_passed; ruff=clean; ruff_format=clean; pyrefly=0_errors; head=e5c226196a4fbdf0c4cb9616863635a77052c5da
+changed_lines: production=0; native_active_attempt_pre_persistence=0; authorized_artifact=verify-report-only
+```
+
+### Canonical Verification Evidence Preimage
+The exact UTF-8 bytes hashed by `evidence_revision` are:
+```text
+checkout-end-to-end
+head=e5c226196a4fbdf0c4cb9616863635a77052c5da
+runtime_attempt_revision=sha256:02a7804f56c7692156a14b87b868e4ee2ab42e6df78e5010bb727276eac44d79
+runtime_attempt_ordinal=11
+runtime_attempt_outcome=running
+test_command=uv run python -m pytest -q
+test_exit_code=0
+test_output_hash=sha256:58891bfffd32f8b1cfacf2654439c654ac0f1549548ceac70e8df0b062b47d7d
+test_summary=246 passed, 1 warning in 11.24s
+ruff_check_command=uv run ruff check .
+ruff_check_exit_code=0
+ruff_check_output_hash=sha256:82b3e6a6c090a57601d22943bd23fca9218d1031dbe5a7b754092f9a156b4f18
+ruff_format_command=uv run ruff format --check .
+ruff_format_exit_code=0
+ruff_format_output_hash=sha256:4efb24614e1989f8459fcf5942e007e1505a707a6613f549c57c29d48cebc4eb
+build_command=uv run pyrefly check
+build_exit_code=0
+build_output_hash=sha256:f9c423e5173017218922360450fdc085e33b2e0483660820aefccb6fa007ec55
+coverage=unavailable_pytest_cov_not_importable_or_declared
+git_status=authorized_untracked_verify_report_only
+git_diff_check_exit_code=0
+tasks=38/38
+requirements=7/7
+scenarios=12/12
+strict_tdd_cycle_evidence=missing
+strict_tdd_exception=maintainer_approved_historical_only
+strict_tdd_exception_waiver_semantics=not_defined_by_loaded_sdd_verify_skill
+```
+
+### Verdict
+**FAIL**
+Runtime implementation, requirements/scenario coverage, current tests, lint, formatting, typing, assertion-quality audit, and source cleanliness pass. Final SDD verification remains blocked because the loaded Strict TDD protocol requires independently verifiable per-task cycle evidence and defines no maintainer waiver semantics for its absence.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #45

---

## 🏷️ PR Type

- [ ] `type:bug`
- [ ] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [x] `type:chore`
- [ ] `type:breaking-change`

---

## 📝 Summary

- Adds executable structural regression tests for the accepted ADR status and obsolete orders repository path removal.
- Persists the honest checkout verification report without fabricating missing historical Strict TDD cycles.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `backend/app/tests/test_checkout_structural_regressions.py` | Adds five structural regression tests covering tasks 2.8, 4.1, and 4.2. |
| `openspec/changes/checkout-end-to-end/verify-report.md` | Records current verification evidence and the remaining non-waivable historical Strict TDD evidence blocker. |

---

## 🧪 Test Plan

- [x] `cd backend && uv run python -m pytest -q` — 251 passed, 1 warning.
- [x] `cd backend && uv run ruff check .` — passed.
- [x] `cd backend && uv run ruff format --check .` — passed.
- [x] `cd backend && uv run pyrefly check` — 0 errors.
- [x] Started the local PostgreSQL service required by integration tests.

Note: the local `uv run pytest` entry point has a stale virtual-environment shebang; the module invocation above is the passing repository check.

---

## 🤖 Automated Checks

Automated checks are expected to run on this pull request.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] Added exactly one `type:*` label (`type:chore`).
- [x] Ruff check passes.
- [x] Ruff format check passes.
- [x] Pyrefly passes.
- [x] Pytest passes through the module entry point.
- [x] Documentation/evidence updated where necessary.
- [x] Commit follows Conventional Commits format.
- [x] Commit has no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

RDD remains explicitly disabled/unmanaged. This PR does not run review receipts, modify RDD authority, or claim archival approval. The checkout implementation itself is already delivered in PRs #46–#56.