### PR TITLE
docs: align documentation with delivered checkout state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,20 +7,21 @@
 
 ## Overview
 
-EventCommerce is a **modular monolith**: one deployable Python backend composed of bounded contexts that each own their domain model, application services, infrastructure, and API surface. The boundaries are directory-based today; contexts are independent scaffolds and do not yet communicate through a shared event envelope or transactional outbox. MVP Target introduces choreography backed by the outbox and idempotent consumers.
+EventCommerce is a **modular monolith**: one deployable Python backend composed of bounded contexts that each own their domain model, application services, infrastructure, and API surface. Today a synchronous `checkout` context coordinates order creation, inventory reservation, deterministic payment authorization, and order confirmation/cancellation in a single request. Shared data structures — an event envelope, a shared event store (`domain_events`), a transactional outbox (`outbox_events`), and an idempotency store (`processed_events`) — exist and are exercised by that synchronous path. Event choreography backed by an AMQP consumer and an outbox worker is the MVP Target; no broker is wired at runtime yet.
 
 | Horizon | State |
 |---|---|
-| **Now** | Four bounded contexts exist in `backend/app/modules/`: `orders`, `inventory`, `payments`, `notifications`. Each exposes only `GET /_health`. No shared event store, outbox, idempotency, RabbitMQ publisher, or `dependency-injector` containers exist in the published tree. |
-| **MVP Target** | Add `iam`, `catalog`, `cart`, and a `checkout` orchestrator; introduce a shared event envelope, event store, transactional outbox, idempotency store, and RabbitMQ publisher/consumer; bootstrap the AMQP consumer and outbox worker; replace the random payment stub with a deterministic simulated provider. |
+| **Now** | Five bounded contexts exist in `backend/app/modules/`: `orders`, `inventory`, `payments`, `notifications`, and `checkout`. Orders exposes `POST /api/v1/orders`, `GET /api/v1/orders/{order_id}`, and `GET /api/v1/orders/{order_id}/timeline`; checkout exposes `POST /api/v1/checkout`. Shared event store, transactional outbox, idempotency store, and `dependency-injector` containers are implemented and wired. Inventory, payments, and notifications expose only `GET /api/v1/{module}/_health`. |
+| **MVP Target** | Add `iam`, `catalog`, and `cart`; wire the existing RabbitMQ publisher and outbox worker into a runtime and add an AMQP consumer so contexts react to published events; reach the five-state order lifecycle; add confirm/cancel HTTP routes. |
 | **Future** | Real payment provider, saga orchestration, dead-letter handling, observability stack, frontend. |
 
 ## Topology
 
 ```mermaid
 flowchart LR
-    subgraph API["API Layer (FastAPI v1)"]
-        ORD["/api/v1/orders/_health<br/>Now"]
+    subgraph API["API Layer (FastAPI)"]
+        ORD["/api/v1/orders*<br/>Now"]
+        CHK["POST /api/v1/checkout<br/>Now"]
         INV["/api/v1/inventory/_health<br/>Now"]
         PAY["/api/v1/payments/_health<br/>Now"]
         NOT["/api/v1/notifications/_health<br/>Now"]
@@ -34,19 +35,22 @@ flowchart LR
         I["inventory"]
         P["payments"]
         N["notifications"]
+        CH["checkout"]
         M["iam<br/>Target"]
         C["catalog<br/>Target"]
         R["cart<br/>Target"]
     end
 
-    subgraph SHARED["Shared Infrastructure — MVP Target"]
-        ES["Event Store<br/>domain_events"]
-        OB["Outbox<br/>outbox_events"]
-        PE["Processed Events<br/>idempotency"]
-        RP["RabbitMQ Publisher"]
+    subgraph SHARED["Shared Infrastructure"]
+        ES["Event Store<br/>domain_events<br/>Now"]
+        OB["Outbox<br/>outbox_events<br/>Now"]
+        PE["Processed Events<br/>idempotency<br/>Now"]
+        RP["RabbitMQ Publisher<br/>module, not wired"]
+        AMQP["AMQP consumer<br/>MVP Target"]
     end
 
     ORD --> O
+    CHK --> CH
     INV --> I
     PAY --> P
     NOT --> N
@@ -54,26 +58,23 @@ flowchart LR
     CAT -.-> C
     CART -.-> R
 
-    O -.-> ES
-    I -.-> ES
-    P -.-> ES
-    N -.-> ES
-    O -.-> OB
-    I -.-> OB
-    P -.-> OB
-    N -.-> OB
+    CH --> O
+    CH --> I
+    CH --> P
+    CH --> N
+    O --> ES
+    O --> OB
+    CH --> OB
+    CH --> PE
     OB -.-> RP
-    RP -.->|AMQP consumer Target| O
-    RP -.->|AMQP consumer Target| I
-    RP -.->|AMQP consumer Target| P
-    RP -.->|AMQP consumer Target| N
-    O -.-> PE
-    I -.-> PE
-    P -.-> PE
-    N -.-> PE
+    RP -.-> AMQP
+    AMQP -.-> O
+    AMQP -.-> I
+    AMQP -.-> P
+    AMQP -.-> N
 ```
 
-Solid arrows are **Now**; dashed arrows are **MVP Target**. No shared infrastructure exists yet; the dashed paths show what the MVP Target will wire.
+Solid arrows are **Now**; dashed arrows are **MVP Target**. Checkout calls the order, inventory, payment, and notification contexts synchronously and persists to the shared outbox and idempotency store. The RabbitMQ publisher module exists but is not wired into the app runtime; nothing forwards outbox events to a broker and no AMQP consumer exists.
 
 ## Bounded contexts
 
@@ -81,10 +82,11 @@ Solid arrows are **Now**; dashed arrows are **MVP Target**. No shared infrastruc
 
 | Context | Responsibility | API state |
 |---|---|---|
-| `orders` | Order aggregate lifecycle and state machine (`pending`, `inventory_reserved`, `payment_authorized`, `confirmed`, `cancelled`). | **Partial** — only `GET /api/v1/orders/_health` exposed. |
-| `inventory` | Stock reservation and release. | **Partial** — use cases exist; only `GET /_health` exposed. |
-| `payments` | Authorization and failure handling. | **Partial** — use cases exist; only `GET /_health` exposed. |
-| `notifications` | Reactions to order events. | **Partial** — use cases exist; only `GET /_health` exposed. |
+| `orders` | Order aggregate lifecycle. Current machine is `pending` → `confirmed`/`cancelled` (see [Order state machine](#order-state-machine)); the five-state lifecycle is MVP Target. | **Implemented** — `POST /api/v1/orders`, `GET /api/v1/orders/{order_id}`, `GET /api/v1/orders/{order_id}/timeline`. |
+| `checkout` | Synchronous commerce orchestrator: order creation, inventory reservation, deterministic payment authorization, order confirmation/cancellation, outbox + idempotency writes. | **Implemented** — `POST /api/v1/checkout`. |
+| `inventory` | Stock reservation and release with row-level locking (`FOR UPDATE`, deadlock-safe ordering). | **Partial** — use cases and locking are exercised via checkout; only `GET /api/v1/inventory/_health` exposed. |
+| `payments` | Authorization and failure handling behind a deterministic simulated policy. | **Partial** — implemented and exercised via checkout; only `GET /api/v1/payments/_health` exposed. |
+| `notifications` | Best-effort notification intent after checkout commits. | **Partial** — use case invoked by checkout; only `GET /api/v1/notifications/_health` exposed. |
 
 ### Target contexts (MVP)
 
@@ -93,7 +95,6 @@ Solid arrows are **Now**; dashed arrows are **MVP Target**. No shared infrastruc
 | `iam` | JWT registration, login, and role authorization as an owned bounded context. |
 | `catalog` | Product browsing and catalog management. |
 | `cart` | Purchase collection before checkout. |
-| `checkout` | Orchestrates cart, inventory, and payment in one request. |
 
 Event names, producers, and consumers are governed by [docs/GLOSSARY.md](./docs/GLOSSARY.md). This document does not duplicate that table.
 
@@ -107,7 +108,7 @@ Each context follows the same layering:
 domain/        — entities, value objects, domain services, domain errors
 application/   — use cases, transaction/coordination logic, no framework imports
 infrastructure/— SQLAlchemy models/repositories, messaging adapters
-api/           — FastAPI routes, schemas, dependency-injector container (MVP Target)
+api/           — FastAPI routes, schemas, dependency-injector container
 ```
 
 Rules:
@@ -121,20 +122,21 @@ Rules:
 
 | Pattern | State | Notes |
 |---|---|---|
-| **Shared event store** | **MVP Target** | Planned path `backend/app/shared/events/`; no code in published tree. |
-| **Shared event envelope** | **MVP Target** | Planned path `backend/app/shared/messaging/envelope.py`; no code in published tree. |
-| **Transactional outbox** | **MVP Target** | Planned path `backend/app/shared/messaging/outbox_repository.py`; no code in published tree. |
-| **RabbitMQ publisher** | **MVP Target** | Planned path `backend/app/shared/messaging/rabbitmq_publisher.py`; no code in published tree. |
-| **AMQP consumer** | **MVP Target** | No consumer code in published tree. |
-| **Idempotent consumers** | **MVP Target** | Planned path `backend/app/shared/messaging/idempotency.py`; no code in published tree. |
-| **Choreography** | **MVP Target** | Contexts will react to published events without a central orchestrator once the outbox and AMQP consumer are implemented. |
+| **Shared event store** | **Now** | `backend/app/shared/events/` — `DomainEvent` base, `domain_events` table, `SqlAlchemyEventRepository`. Orders persists `OrderCreated` and reads timelines from it. |
+| **Shared event envelope** | **Now** | `backend/app/shared/messaging/envelope.py` — `EventEnvelope` with an `event_type` literal. |
+| **Transactional outbox** | **Now (emission)** | `backend/app/shared/messaging/outbox_repository.py` + `outbox_events` table. Checkout and orders persist `OrderCreated` / `OrderConfirmed` / `OrderCancelled`. Forwarding to a broker is not wired. |
+| **RabbitMQ publisher** | **Partial** | `backend/app/shared/messaging/rabbitmq_publisher.py` exists (aio-pika) but is not connected or started by the app runtime. |
+| **Outbox worker** | **Partial** | `backend/app/shared/messaging/outbox_worker.py` exists; no scheduler or lifespan integration. |
+| **AMQP consumer** | **MVP Target** | No consumer module. |
+| **Idempotent consumers** | **Now (primitives)** | `backend/app/shared/messaging/idempotency.py` — `ProcessedEventStore` claims and response cache used end-to-end by checkout. Wired AMQP consumers remain MVP Target. |
+| **Choreography** | **MVP Target** | Contexts will react to published events without a central orchestrator once the outbox worker and AMQP consumer are wired. The current checkout is a deliberate synchronous commerce path. |
 
 ### Persistence topology
 
 - **PostgreSQL** is the single persistence store.
 - Each bounded context owns its tables (`orders`, `inventory`, `payments`, `notifications`).
-- Shared tables (`outbox_events`, `processed_events`, `domain_events`) and the shared infrastructure layer are **MVP Target**.
-- Migrations live in `backend/alembic/versions/` (currently empty).
+- Shared tables `outbox_events`, `processed_events`, and `domain_events` live under `backend/app/shared/` and are **Now**.
+- Migrations live in `backend/alembic/versions/` (six migrations covering the initial schema, shared domain events, checkout idempotency, and payments tables).
 
 ## Cross-cutting concerns
 
@@ -144,11 +146,11 @@ Rules:
 
 ### Error handling
 
-Each bounded context owns domain errors (`InvalidStateTransitionError`, `OrderNotFoundError`, `PaymentRejectedError`, etc.). Application use cases raise domain errors; API routes translate them to HTTP responses (e.g., `OrderNotFoundError` → 404). This is **Now** for orders; **MVP Target** for the remaining contexts.
+Each bounded context owns domain errors (`InvalidStateTransitionError`, `OrderNotFoundError`, `PaymentRejectedError`, etc.). Application use cases raise domain errors; API routes translate them to HTTP responses (e.g., `OrderNotFoundError` → 404, `IdempotencyConflictError` → 409, unexpected failures → 500 with a rollback). This is **Now** for orders and checkout; inventory and payments errors are raised and handled through the checkout path.
 
 ### Security and auth boundaries
 
-There is no authentication or authorization code today. Health-only endpoints run without auth; business API/auth are MVP Target. IAM as an owned bounded context with JWT registration, login, and role enforcement is an **MVP Target**. Planned ADR: [0004-own-iam-context](./docs/adr/0004-own-iam-context.md).
+There is no authentication or authorization code today; all endpoints (health, orders, and checkout) run without auth. IAM as an owned bounded context with JWT registration, login, and role enforcement is an **MVP Target**. Recorded in [0004-own-iam-context](./docs/adr/0004-own-iam-context.md).
 
 ### Observability
 
@@ -156,15 +158,15 @@ The backend uses standard Python logging only. Structured logs, correlation IDs,
 
 ### DI container strategy
 
-`dependency-injector` per-module containers are **MVP Target**. No `OrdersContainer`, `InventoryContainer`, `PaymentsContainer`, or `NotificationsContainer` exists in the published tree. Planned ADR: [0003-use-dependency-injector](./docs/adr/0003-use-dependency-injector.md).
+`dependency-injector` per-module containers are **Now**: `OrdersContainer`, `InventoryContainer`, `PaymentsContainer`, `NotificationsContainer`, and `CheckoutContainer` exist under `backend/app/modules/*/api/container.py` and are wired in `backend/app/app.py`. Recorded in [0003-use-dependency-injector](./docs/adr/0003-use-dependency-injector.md).
 
 ### Request-scoped session management
 
-Request-scoped session override via a `dependency-injector` container is **MVP Target**. Current routes use plain FastAPI routers without container wiring.
+Request-scoped session override via a `dependency-injector` container is **Now**. Routes override the module container's `session` provider with the request's `AsyncSession` and reset the override in a `finally` block, so each request shares one transaction across repositories and use cases.
 
 ### Consistency and idempotency
 
-Idempotent consumer primitives (`ProcessedEventStore`, `processed_events` unique constraint, and the outbox pattern) are **MVP Target**; no code exists in the published tree. Wired consumers that exercise them end-to-end are also **MVP Target**. Domain terms are defined in [docs/GLOSSARY.md](./docs/GLOSSARY.md).
+Idempotency primitives (`ProcessedEventStore`, the `processed_events` table, and the outbox pattern) are **Now** and are exercised end-to-end by checkout: claims with a transaction-scoped advisory lock, durable response cache, and `409` on payload mismatch. Wired consumers that react to published events are **MVP Target**. Domain terms are defined in [docs/GLOSSARY.md](./docs/GLOSSARY.md).
 
 ## Non-functional requirements
 
@@ -172,10 +174,10 @@ The table below tags every target as **Now**, **MVP Target**, or **Future**. Any
 
 | Concern | Horizon | Target | How measured |
 |---|---|---|---|
-| Order state correctness | Now | 100% of simulated orders end in a valid terminal state with the expected event sequence | Domain tests assert the transitions in `backend/app/modules/orders/domain/services/order_domain_service.py`. |
-| Consumer idempotency | MVP Target | Replaying the same event batch produces zero duplicate inventory, payment, or notification records | Replay test counts rows before/after. |
-| Payment simulation reproducibility | MVP Target | Identical inputs produce the same authorization result across 100 repeated runs | Fixed-seed / deterministic policy test. |
-| End-to-end checkout latency | MVP Target | p95 < 500 ms on the deterministic local path | pytest benchmark around checkout use case. |
+| Order state correctness | Now | 100% of simulated orders end in a valid terminal state with the expected event sequence | Domain tests assert the transitions in `backend/app/modules/orders/domain/services.py`. |
+| Consumer idempotency | Now (checkout path) | Replaying an `Idempotency-Key` produces zero duplicate order, inventory, or payment records | Replay tests around `ProcessedEventStore` and the checkout use case; wired AMQP-consumer replay is MVP Target. |
+| Payment simulation reproducibility | Now | Identical inputs produce the same authorization result across repeated runs | Deterministic policy tests in `backend/app/modules/payments/tests/test_payment_policy.py`. |
+| End-to-end checkout latency | MVP Target | p95 < 500 ms on the deterministic local path | pytest benchmark around the checkout use case; benchmark evidence is not yet produced. |
 | API health latency | Now | p95 < 100 ms for `GET /health` and module `_health` endpoints | httpx timing against local server. |
 | Domain + application test coverage | Now | ≥ 80% of domain and application use-case lines covered | `pytest --cov` over `backend/app/modules/*/domain/` and `application/`. |
 | Local reproducibility | Now | `pytest` passes locally without external secrets or paid services | CI / local run. |
@@ -189,84 +191,90 @@ The table below tags every target as **Now**, **MVP Target**, or **Future**. Any
 
 | Decision | Horizon | Status | Code evidence | Doc location |
 |---|---|---|---|---|
-| Bounded context scaffold: orders, inventory, payments, notifications | Now | implemented | `backend/app/modules/orders/`, `backend/app/modules/inventory/`, `backend/app/modules/payments/`, `backend/app/modules/notifications/` | Bounded contexts |
-| Orders HTTP API surface | Now | partial | `backend/app/modules/orders/api/routes/v1/router.py` exposes only `GET /_health` | API Layer |
-| Inventory / Payments / Notifications HTTP API surface | Now | partial | `backend/app/modules/inventory/api/routes/v1/router.py`, `backend/app/modules/payments/api/routes/v1/router.py`, `backend/app/modules/notifications/api/routes/v1/router.py` expose only `GET /_health` | API Layer |
-| Shared event store (`domain_events`) | MVP Target | target | No code; planned `backend/app/shared/events/` | Patterns |
-| Shared event envelope | MVP Target | target | No code; planned `backend/app/shared/messaging/envelope.py` | Patterns |
-| Transactional outbox models + repository | MVP Target | target | No code; planned `backend/app/shared/messaging/outbox_repository.py` | Patterns |
-| Outbox worker + scheduler | MVP Target | target | No code; planned `backend/app/shared/messaging/outbox_worker.py` | Patterns |
-| RabbitMQ publisher | MVP Target | target | No code; planned `backend/app/shared/messaging/rabbitmq_publisher.py` | Patterns |
-| AMQP consumer / event choreography | MVP Target | target | No consumer code yet | Patterns |
-| Idempotent consumer store (`ProcessedEventStore`) | MVP Target | target | No code; planned `backend/app/shared/messaging/idempotency.py` | Cross-cutting concerns |
-| `processed_events` unique constraint | MVP Target | target | No code; planned `backend/app/shared/messaging/models.py` | Cross-cutting concerns |
+| Bounded context scaffold: orders, inventory, payments, notifications, checkout | Now | implemented | `backend/app/modules/{orders,inventory,payments,notifications,checkout}/` | Bounded contexts |
+| Orders HTTP API surface | Now | implemented | `backend/app/modules/orders/api/routes.py` — `POST /api/v1/orders`, `GET /api/v1/orders/{order_id}`, `GET /api/v1/orders/{order_id}/timeline` | API Layer |
+| Checkout HTTP API surface | Now | implemented | `backend/app/modules/checkout/api/routes.py` — `POST /api/v1/checkout` | API Layer |
+| Inventory / Payments / Notifications HTTP API surface | Now | partial | `backend/app/modules/{inventory,payments,notifications}/api/routes.py` expose only `GET /_health` | API Layer |
+| Shared event store (`domain_events`) | Now | implemented | `backend/app/shared/events/` — `models.py`, `event_repository.py`, `repository.py`, `domain.py` | Patterns |
+| Shared event envelope | Now | implemented | `backend/app/shared/messaging/envelope.py` | Patterns |
+| Transactional outbox models + repository | Now | implemented | `backend/app/shared/messaging/outbox_repository.py`, `models.py` | Patterns |
+| Outbox worker + scheduler | MVP Target | partial | `backend/app/shared/messaging/outbox_worker.py` exists; no scheduler or runtime wiring | Patterns |
+| RabbitMQ publisher | MVP Target | partial | `backend/app/shared/messaging/rabbitmq_publisher.py` exists; not wired or connected | Patterns |
+| AMQP consumer / event choreography | MVP Target | target | No consumer code | Patterns |
+| Idempotent consumer store (`ProcessedEventStore`) | Now | implemented | `backend/app/shared/messaging/idempotency.py` | Cross-cutting concerns |
+| `processed_events` table + durable response cache | Now | implemented | `backend/app/shared/messaging/models.py` | Cross-cutting concerns |
 | `pydantic-settings` configuration | Now | implemented | `backend/app/shared/config/settings.py` | Cross-cutting concerns |
-| `dependency-injector` DI containers | MVP Target | target | No code; planned per-module containers under `backend/app/modules/*/api/container.py` | Cross-cutting concerns |
-| Request-scoped session override | MVP Target | target | No container wiring exists; planned with `dependency-injector` | Cross-cutting concerns |
+| `dependency-injector` DI containers | Now | implemented | `backend/app/modules/*/api/container.py`, wired in `backend/app/app.py` | Cross-cutting concerns |
+| Request-scoped session override | Now | implemented | Routes override the module container `session` provider and reset it in `finally` | Cross-cutting concerns |
+| Deterministic simulated payment provider | Now | implemented | `backend/app/modules/payments/domain/policy.py` (ADR 0005) | Patterns |
+| Five-state order lifecycle | MVP Target | partial | Current machine is `pending` → `confirmed`/`cancelled`; `inventory_reserved` / `payment_authorized` intermediate states are not reachable | Order state machine |
+| Confirm/cancel HTTP routes | MVP Target | partial | Use cases `confirm_order.py` / `cancel_order.py` exist; no HTTP routes | API Layer |
 | IAM bounded context (JWT, roles) | MVP Target | target | No code | Bounded contexts |
 | Catalog bounded context | MVP Target | target | No code | Bounded contexts |
 | Cart bounded context | MVP Target | target | No code | Bounded contexts |
-| Checkout orchestrator | MVP Target | target | No code | Bounded contexts |
-| Deterministic simulated payment provider | MVP Target | target | `backend/app/modules/payments/application/authorize_payment.py` still uses a random stub | Patterns |
-| Frontend storefront | Future | target | `frontend/` is empty | Future |
+| Frontend storefront | Future | target | `frontend/` is not created | Future |
 
 ### Commerce event flow
 
-The diagram below shows what is implemented now, what exists as code but is not scheduled, and what is only a target. It deliberately does not draw the AMQP consumer as a live path.
+The diagram below shows the delivered synchronous checkout path and what remains target. It deliberately does not draw the AMQP consumer or outbox forwarding as live.
 
 ```mermaid
 sequenceDiagram
     actor S as Shopper/API
+    participant CHK as checkout (Now)
     participant O as orders (Now)
-    participant OB as outbox_events (Target)
-    participant DE as domain_events (Target)
-    participant RP as RabbitMQPublisher (Target)
-    participant AMQP as order.events exchange (Target)
-    participant I as inventory (Target)
-    participant P as payments (Target)
-    participant N as notifications (Target)
+    participant I as inventory (Now)
+    participant P as payments (Now)
+    participant N as notifications (Now)
+    participant DE as domain_events (Now)
+    participant OB as outbox_events (Now, not forwarded)
+    participant RP as RabbitMQPublisher (module, not wired)
 
-    S->>O: GET /api/v1/orders/_health (Now)
-    Note over O: Current routes are health-only; no wired event flow exists.
-    S->>O: Target: POST /api/v1/orders
-    O->>OB: Target: persist OrderCreated outbox event
-    O->>DE: Target: record OrderCreated domain event
-    Note over OB: Outbox worker and scheduler are Target
-    OB-->>RP: Target: polled + published when worker runs
-    RP-->>AMQP: Target: publish to topic exchange
-    Note right of AMQP: No AMQP consumer exists yet (Target)
-    AMQP-->>I: Target: InventoryReserved / InventoryRejected
-    I-->>O: Target: confirm or cancel order
-    O-->>P: Target: authorize payment
-    O-->>N: Target: send notification
+    S->>CHK: POST /api/v1/checkout
+    CHK->>O: create order (pending)
+    O-->>DE: record OrderCreated
+    O-->>OB: persist OrderCreated (pending)
+    CHK->>I: lock_and_check_availability + reserve
+    alt payment approved (deterministic policy)
+        CHK->>P: authorize payment
+        CHK->>O: confirm order (confirmed)
+        CHK-->>OB: persist OrderConfirmed (pending)
+    else stock rejected or payment rejected
+        CHK->>O: cancel order (cancelled)
+        CHK->>I: release inventory on payment failure
+        CHK-->>OB: persist OrderCancelled (pending)
+    end
+    CHK->>N: best-effort notification
+    Note over OB: No outbox worker/scheduler or AMQP consumer is wired; nothing forwards these events to a broker.
+    OB-.->RP: Target: polled + published when the worker is wired
 ```
 
 ### Order state machine
 
-The transition set below matches `can_transition` in `backend/app/modules/orders/domain/services/order_domain_service.py` exactly, including idempotent self-transitions. See [docs/GLOSSARY.md](./docs/GLOSSARY.md) for state vocabulary.
+The transition set below matches `can_transition` in `backend/app/modules/orders/domain/services.py` exactly, including idempotent self-transitions. See [docs/GLOSSARY.md](./docs/GLOSSARY.md) for state vocabulary.
 
 ```mermaid
 stateDiagram-v2
     [*] --> pending: create order
-    pending --> inventory_reserved: reserve stock
+    pending --> confirmed: payment authorized (synchronous checkout)
     pending --> cancelled: stock rejected / payment rejected
-    inventory_reserved --> payment_authorized: authorize payment
-    inventory_reserved --> cancelled: payment rejected
-    payment_authorized --> confirmed: payment accepted
-    payment_authorized --> cancelled: payment rejected
+    confirmed --> confirmed: idempotent self-transition
+    cancelled --> cancelled: idempotent self-transition
 ```
+
+The full five-state lifecycle (`inventory_reserved`, `payment_authorized` as reachable intermediate states) is **MVP Target** and is not reachable in the current machine.
 
 ## Architecture Decision Records
 
-Significant decisions are recorded in `docs/adr/`. The following ADRs are planned and will be authored in the W5 slice:
+Significant decisions are recorded in `docs/adr/`. Status rules and the full index live in [docs/adr/README.md](./docs/adr/README.md). Current status:
 
-| # | Slug | Decision |
+| # | Slug | Status |
 |---|---|---|
-| 0001 | [use-shared-event-store](./docs/adr/0001-use-shared-event-store.md) | Use a single shared event store instead of per-module event tables. |
-| 0002 | [use-choreography](./docs/adr/0002-use-choreography.md) | Use event choreography rather than a central saga orchestrator for the MVP. |
-| 0003 | [use-dependency-injector](./docs/adr/0003-use-dependency-injector.md) | Use `dependency-injector` for per-module containers and request-scoped session override. |
-| 0004 | [own-iam-context](./docs/adr/0004-own-iam-context.md) | Make IAM an owned bounded context with JWT registration/login/roles. |
-| 0005 | [use-deterministic-simulated-payments](./docs/adr/0005-use-deterministic-simulated-payments.md) | Keep payments behind ports/adapters and use a deterministic simulated provider for the MVP. |
+| 0001 | [use-shared-event-store](./docs/adr/0001-use-shared-event-store.md) | Accepted (current implementation) |
+| 0002 | [use-choreography](./docs/adr/0002-use-choreography.md) | Partially implemented — messaging primitives live; consumer wiring is MVP Target |
+| 0003 | [use-dependency-injector](./docs/adr/0003-use-dependency-injector.md) | Accepted (current implementation) |
+| 0004 | [own-iam-context](./docs/adr/0004-own-iam-context.md) | Accepted (MVP Target) |
+| 0005 | [use-deterministic-simulated-payments](./docs/adr/0005-use-deterministic-simulated-payments.md) | Accepted (current implementation) |
 
 ## Future roadmap
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -125,7 +125,7 @@ components:
 # Design
 
 > **Target Design Notice**
-> This document describes the intended user experience for the eventcommerce MVP. The project currently has no frontend implementation and the `frontend/` directory is reserved. Only the **Now** column in the flows and inventory below is binding today; the **MVP Target** column is the design north star for the next vertical slice. Product scope lives in [PRD.md](./PRD.md), system structure in [ARCHITECTURE.md](./ARCHITECTURE.md), domain vocabulary in [docs/GLOSSARY.md](./docs/GLOSSARY.md), and decisions in the [ADR index](./docs/adr/README.md).
+> This document describes the intended user experience for the eventcommerce MVP. There is no frontend implementation and the `frontend/` directory is reserved. The backend exposes a synchronous `POST /api/v1/checkout` and an orders HTTP API, but all consumer-facing flows below are still target UI. Only the **Now** column in the flows and inventory below is binding today; the **MVP Target** column is the design north star for the next vertical slice. Product scope lives in [PRD.md](./PRD.md), system structure in [ARCHITECTURE.md](./ARCHITECTURE.md), domain vocabulary in [docs/GLOSSARY.md](./docs/GLOSSARY.md), and decisions in the [ADR index](./docs/adr/README.md).
 
 ## Overview
 
@@ -142,7 +142,7 @@ This document owns the target screen map, user flows, visual tokens, component s
 | Browse catalog | API-only; no UI | Catalog page with filters, search, and stock signal |
 | Add to cart | API-only; no UI | Cart drawer/page with line items, quantities, and subtotal |
 | Review checkout | API-only; no UI | Checkout summary with shipping, payment stub, and place-order CTA |
-| Place order | `POST /api/v1/orders` | Same endpoint, surfaced through checkout form |
+| Place order | `POST /api/v1/checkout` (synchronous) | Same commerce path, surfaced through a checkout form |
 | View order status | `GET /api/v1/orders/{id}` | Order tracking page with live status and timeline |
 | Receive result | Raw JSON response | In-context success, failure, or pending message |
 
@@ -172,6 +172,8 @@ flowchart TD
     H --> K[Poll or listen for update]
     K --> E
 ```
+
+The current backend resolves checkout synchronously: `POST /api/v1/checkout` returns a terminal `confirmed` or `cancelled` order in one request, so the `Still waiting` / poll path above only applies once event-driven consumption is wired (MVP Target).
 
 ## Screen inventory
 

--- a/PRD.md
+++ b/PRD.md
@@ -26,23 +26,22 @@ Event-driven systems quickly become hard to reason about when vocabulary, owners
 
 ## Now
 
-- Python backend scaffold in `backend/app/` with `orders`, `inventory`, `payments`, and `notifications` bounded contexts; each module currently exposes only a `GET /_health` route.
-- Order aggregate supports `pending`, `inventory_reserved`, `payment_authorized`, `confirmed`, and `cancelled`; no checkout orchestrator exists.
-- No shared event envelope, transactional outbox, idempotency store, RabbitMQ publisher, or `dependency-injector` containers exist in the published tree.
-- Payment authorization is currently a non-deterministic stub: `random.choice([True, True, True, False])`.
-- **Not yet live**: AMQP consumer, outbox worker/scheduler, IAM, catalog, cart, checkout, shared messaging, and frontend.
+- Modular Python backend in `backend/app/` with `orders`, `inventory`, `payments`, `notifications`, and `checkout` bounded contexts wired with `dependency-injector`.
+- Orders HTTP API (`POST /api/v1/orders`, `GET /api/v1/orders/{order_id}`, `GET /api/v1/orders/{order_id}/timeline`) and a synchronous checkout at `POST /api/v1/checkout`.
+- Checkout coordinates order creation, inventory reservation, deterministic payment authorization, and order confirmation/cancellation in one request, with durable `Idempotency-Key` handling: a replay returns the cached response, and a reused key with a different payload returns `409`.
+- Shared event envelope, event store, and transactional outbox data structures exist; checkout and orders persist `OrderCreated` / `OrderConfirmed` / `OrderCancelled` events.
+- Deterministic simulated payment policy (ADR 0005) replaces the former random stub.
+- **Not yet live**: AMQP consumer/runtime, outbox scheduler/worker lifespan integration, IAM/JWT/roles, catalog, cart, the five-state order lifecycle, confirm/cancel HTTP routes, and the storefront frontend.
 
 ## MVP Target
 
-A full commerce journey on a single event-driven backend:
+The remaining journey on a single event-driven backend. Checkout, deterministic simulated payments, and the shared event/outbox/idempotency primitives are already delivered (see [Now](#now)); the following close out the MVP:
 
 - **IAM** as an owned bounded context with JWT registration, login, and role authorization.
 - **Catalog** and **Cart** contexts for product browsing and purchase collection.
-- **Checkout** orchestrating cart, inventory, and payment in one request.
-- **Orders** context with a state machine supporting `pending`, `inventory_reserved`, `payment_authorized`, `confirmed`, and `cancelled`.
-- **Inventory** context reserving and releasing stock through events.
-- **Payments** context behind ports/adapters with a **deterministic simulated provider**.
-- **Notifications** context reacting to order events.
+- **Orders** reaching the full five-state lifecycle (`pending`, `inventory_reserved`, `payment_authorized`, `confirmed`, `cancelled`) driven by event choreography.
+- **Inventory** reserving and releasing stock through events.
+- **Notifications** reacting to order events.
 - **Event choreography** backed by the transactional outbox and idempotent consumers.
 
 ## Future
@@ -53,12 +52,13 @@ A full commerce journey on a single event-driven backend:
 
 ## Business Rules
 
-- A checkout can only be submitted when every cart line has available inventory.
-- Inventory is reserved before payment authorization is attempted.
-- Payment authorization in the MVP must be deterministic: identical inputs always return the same result.
-- Order state transitions are `pending` → `{inventory_reserved, cancelled}`, `inventory_reserved` → `{payment_authorized, cancelled}`, and `payment_authorized` → `{confirmed, cancelled}`; no other transitions are allowed.
-- Consumers must be idempotent: processing the same event twice must not duplicate side effects.
-- JWT tokens carry roles; role authorization is enforced at API boundaries.
+- A checkout can only be submitted when every cart line has available inventory. (Now)
+- Inventory is reserved before payment authorization is attempted. (Now)
+- Payment authorization must be deterministic: identical inputs always return the same result. (Now)
+- Order status transitions in the current synchronous checkout are `pending` → `{confirmed, cancelled}`, with idempotent self-transitions on terminal states. (Now)
+- MVP Target — five-state lifecycle: order state transitions become `pending` → `{inventory_reserved, cancelled}`, `inventory_reserved` → `{payment_authorized, cancelled}`, and `payment_authorized` → `{confirmed, cancelled}`; no other transitions are allowed.
+- Consumers must be idempotent: processing the same event twice must not duplicate side effects. (Now for the checkout path; wired consumers are MVP Target)
+- JWT tokens carry roles; role authorization is enforced at API boundaries. (MVP Target)
 
 ## Non-goals
 
@@ -70,10 +70,10 @@ A full commerce journey on a single event-driven backend:
 
 ## Metrics
 
-- **Order state correctness**: 100% of simulated orders end in a valid terminal state following the transitions in `backend/app/modules/orders/domain/services/order_domain_service.py`.
-- **Payment simulation reproducibility**: a fixed input set produces the same authorization result across 100 repeated runs.
-- **Consumer idempotency**: replaying the same event batch produces no duplicate inventory or payment records.
-- **End-to-end checkout latency**: p95 under 500 ms for the deterministic MVP path in local tests.
+- **Order state correctness** (Now): 100% of simulated orders end in a valid terminal state following the transitions in `backend/app/modules/orders/domain/services.py` (`pending` → `{confirmed, cancelled}`).
+- **Payment simulation reproducibility** (Now): a fixed input set produces the same authorization result across repeated runs.
+- **Consumer idempotency** (Now for the checkout path): replaying an `Idempotency-Key` produces no duplicate order, inventory, or payment records; wired AMQP-consumer replay is MVP Target.
+- **End-to-end checkout latency** (MVP Target): p95 under 500 ms for the deterministic MVP path in local tests; benchmark evidence is not yet produced.
 
 ## Glossary
 

--- a/README.md
+++ b/README.md
@@ -6,26 +6,28 @@ A product-quality portfolio project: a modular, event-driven commerce backend th
 
 ### Now
 
-- Python backend scaffold in `backend/app/` with `orders`, `inventory`, `payments`, and `notifications` bounded contexts; each module currently exposes only a `GET /_health` route.
-- Order aggregate in the `orders` context supports `pending`, `inventory_reserved`, `payment_authorized`, `confirmed`, and `cancelled`.
-- No shared event envelope, transactional outbox, idempotency store, RabbitMQ publisher, or `dependency-injector` containers exist in the published tree.
-- FastAPI application structure, SQLAlchemy 2 async mappings, and module scaffolds exist.
-- **Not yet live**: AMQP consumer, outbox worker/scheduler, IAM, catalog, cart, checkout, shared messaging, and frontend.
+- Modular Python backend in `backend/app/` with `orders`, `inventory`, `payments`, `notifications`, and `checkout` bounded contexts, wired through `dependency-injector` per-module containers.
+- Orders HTTP API: `POST /api/v1/orders`, `GET /api/v1/orders/{order_id}`, and `GET /api/v1/orders/{order_id}/timeline`.
+- Synchronous checkout at `POST /api/v1/checkout`: creates the order, locks and reserves inventory (row-level `FOR UPDATE`), authorizes payment with a deterministic simulated policy (ADR 0005), and reaches `confirmed` or `cancelled` in one request.
+- Durable idempotency and response cache: `Idempotency-Key` claims with replay detection and `409` on payload mismatch, backed by the `processed_events` table.
+- Shared event envelope, event store (`domain_events`), and transactional outbox (`outbox_events`) data structures; checkout and orders persist events to them.
+- Quality checks in CI: `ruff check`, `ruff format --check`, `pyrefly check`, and `pytest`.
+- **Not yet live**: AMQP consumer/runtime, outbox scheduler/worker lifespan integration, IAM/JWT/roles, catalog, cart, the five-state order lifecycle, confirm/cancel HTTP routes, and the storefront frontend. The RabbitMQ publisher and outbox worker modules exist but are not wired into the running app.
 
 ### MVP Target
 
-A full commerce journey on a single event-driven backend:
+The remaining commerce journey on a single event-driven backend:
 
 - IAM as an owned bounded context with JWT registration, login, and role authorization.
-- Catalog, cart, checkout, orders, inventory, deterministic simulated payments, and notifications.
-- Event choreography backed by the transactional outbox and idempotent consumers.
-- The payment provider is a deterministic simulation behind real ports/adapters; no random outcomes as business behavior.
+- Catalog and cart contexts for product browsing and purchase collection.
+- Live event choreography: wire the AMQP consumer and outbox worker so contexts react to published events instead of the synchronous checkout path.
+- The full five-state order lifecycle (`pending` → `inventory_reserved` → `payment_authorized` → `confirmed`/`cancelled`) and confirm/cancel HTTP routes.
 
 ### Future
 
 - Real payment provider adapter.
 - Saga orchestration and dead-letter handling.
-- Observability stack, runbooks, and a frontend.
+- Observability stack, runbooks, and a storefront frontend.
 
 ## Five-minute path
 
@@ -43,7 +45,7 @@ A full commerce journey on a single event-driven backend:
 | `backend/alembic/` | Database migrations |
 | `docs/` | Glossary and Architecture Decision Records |
 | `openspec/` | SDD change specifications and tasks |
-| `frontend/` | Reserved for future frontend work (currently empty) |
+| `frontend/` | Reserved for future frontend work (not created yet) |
 | `.github/` | CI and PR templates |
 
 ## Documentation index

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,14 +1,15 @@
 # EventCommerce Backend
 
-Base inicial del backend con:
+Python backend for EventCommerce with:
 
 - uv
 - FastAPI
 - Pydantic Settings
-- SQLAlchemy
+- SQLAlchemy (async)
+- dependency-injector
 - Pyrefly
 
-## Ejecutar
+## Run
 
 ```bash
 uv sync
@@ -16,46 +17,54 @@ cp .env.example .env
 uv run eventcommerce-backend
 ```
 
-Base de datos por defecto esperada:
+Default expected database:
 
 ```env
 EVENTCOMMERCE_DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/eventcommerce
 ```
 
-## Estructura
+## Test and quality
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run pyrefly check
+```
+
+## Structure
 
 ```text
 app/
   modules/
     orders/
-      api/
-        routes/v1/
-        schemas/
+      api/            — routes.py, schemas.py, container.py
       application/
       domain/
       infrastructure/
+    checkout/
+      api/
+      application/
     inventory/
       api/
-        routes/v1/
-        schemas/
       application/
       domain/
       infrastructure/
     payments/
       api/
-        routes/v1/
-        schemas/
       application/
       domain/
       infrastructure/
     notifications/
       api/
-        routes/v1/
-        schemas/
       application/
       domain/
       infrastructure/
   shared/
     config/
     db/
+    events/           — shared event store (domain_events)
+    messaging/        — envelope, outbox, idempotency, publisher, worker
 ```
+
+Modules follow a flat layout: `api/routes.py`, `api/schemas.py`, and `api/container.py` (dependency-injector) instead of nested `api/routes/v1/router.py`. Migrations live in `alembic/versions/`.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -12,21 +12,22 @@ Canonical domain and event vocabulary for `eventcommerce`. Use this document to 
 
 | Term | Definition | Horizon |
 |---|---|---|
-| Bounded context | A module that owns its own domain model, data, and invariants (e.g., `orders`, `inventory`). | Now / Target |
-| Event envelope | The canonical wire format that carries event metadata and payload across contexts. | MVP Target |
+| Bounded context | A module that owns its own domain model, data, and invariants (e.g., `orders`, `inventory`, `checkout`). | Now / Target |
+| Event envelope | The canonical wire format that carries event metadata and payload across contexts. The model exists at `backend/app/shared/messaging/envelope.py`; using it across contexts via a broker is MVP Target. | Now (structure) / Target (use) |
 | Choreography | Contexts react to published events rather than following a central orchestrator. | MVP Target |
-| Transactional outbox | Events are persisted atomically with business state, then forwarded to a broker. | MVP Target |
-| Idempotency | Processing the same event twice must not duplicate side effects. | MVP Target |
-| Deterministic simulated payment | A payment provider that returns the same authorization result for the same inputs. | MVP Target |
+| Transactional outbox | Events are persisted atomically with business state, then forwarded to a broker. Emission is implemented (`outbox_events`); forwarding to a broker is not wired. | Now (emission) / Target (forwarding) |
+| Idempotency | Processing the same event twice must not duplicate side effects. Implemented for the checkout path (`processed_events`); wired AMQP consumers are MVP Target. | Now (checkout path) |
+| Deterministic simulated payment | A payment provider that returns the same authorization result for the same inputs. Implemented in `backend/app/modules/payments/domain/policy.py` (ADR 0005). | Now |
 
 ### Bounded contexts
 
 **Current contexts** (`backend/app/modules/`):
 
 - `orders` — order lifecycle and state machine.
-- `inventory` — stock reservation and release.
-- `payments` — authorization and failure handling.
-- `notifications` — reactions to order events.
+- `checkout` — synchronous commerce orchestrator (`POST /api/v1/checkout`).
+- `inventory` — stock reservation and release with row-level locking.
+- `payments` — authorization and failure handling behind a deterministic policy.
+- `notifications` — best-effort notification intent.
 
 **Target contexts** (MVP):
 
@@ -36,47 +37,42 @@ Canonical domain and event vocabulary for `eventcommerce`. Use this document to 
 
 ## Events
 
-Current events live in per-module `domain/events/` files. The shared envelope and the target event vocabulary are **MVP Target** and will live in `backend/app/shared/messaging/envelope.py`.
+The shared envelope at `backend/app/shared/messaging/envelope.py` defines the canonical `event_type` literal: `OrderCreated`, `InventoryReserved`, `InventoryRejected`, `OrderConfirmed`, and `OrderCancelled`. The shared event store (`backend/app/shared/events/`) persists timeline events; the transactional outbox (`backend/app/shared/messaging/outbox_repository.py`) persists events for later forwarding. Only the `orders` context defines domain event dataclasses today (`backend/app/modules/orders/domain/events.py`); inventory, payments, and notifications have no per-module events module.
 
 ### Current events (Now)
 
 | Event | Meaning | Producer | Consumer | Code path |
 |---|---|---|---|---|
-| `OrderCreated` | A shopper submitted a checkout and an order aggregate was created. | `orders` | `inventory` (Target), `notifications` (Target) | `backend/app/modules/orders/domain/events/order_events.py` |
-| `InventoryReserved` | Requested stock was reserved successfully. | `inventory` | `orders` (Target), `payments` (Target) | `backend/app/modules/inventory/domain/events/inventory_events.py` |
-| `PaymentAuthorized` | A payment was authorized for the order. | `payments` | `orders` (Target), `notifications` (Target) | `backend/app/modules/payments/domain/events/payment_events.py` |
-| `OrderNotificationSent` | A notification was dispatched for an order. | `notifications` | — | `backend/app/modules/notifications/domain/events/notification_events.py` |
+| `OrderCreated` | A shopper submitted a checkout and an order aggregate was created. | `orders` (via `CreateOrder`) | AMQP consumers (Target) | `backend/app/modules/orders/domain/events.py`; persisted to `domain_events` and `outbox_events` |
+| `OrderConfirmed` | The order reached the `confirmed` terminal state. | `checkout` | Notifications (best-effort sync); AMQP consumers (Target) | Outbox write in `backend/app/modules/checkout/application/checkout.py` |
+| `OrderCancelled` | The order reached the `cancelled` terminal state. | `checkout` | Inventory release (on payment failure); AMQP consumers (Target) | Outbox write in `backend/app/modules/checkout/application/checkout.py` |
+| `InventoryReserved` | Requested stock was reserved successfully. | `checkout` (via inventory use cases) | AMQP consumers (Target) | Envelope literal; `orders/domain/events.py` dataclass |
+| `InventoryRejected` | Requested stock could not be reserved. | `checkout` (via inventory use cases) | AMQP consumers (Target) | Envelope literal; `orders/domain/events.py` dataclass |
 
-### Target events (MVP Target)
+### Consumer wiring (MVP Target)
 
-The choreography target adds the shared envelope and these additional events:
-
-| Event | Meaning | Producer | Consumer |
-|---|---|---|---|
-| `InventoryRejected` | Requested stock could not be reserved. | `inventory` | `orders` |
-| `OrderConfirmed` | The order reached a terminal successful state. | `orders` | `notifications` |
-| `OrderCancelled` | The order reached a terminal cancelled state. | `orders` | `inventory`, `notifications` |
+The choreography target wires these events to consumers through the outbox, RabbitMQ publisher, and AMQP consumer. When that wiring is live, `OrderCreated` triggers inventory reservation, `InventoryReserved` / `InventoryRejected` drive order confirmation or cancellation, and terminal events trigger notifications. Until then, none of these events are forwarded to a broker and no consumer reacts to them.
 
 ## State vocabulary
 
 ### Order status
 
-Order statuses are `pending`, `inventory_reserved`, `payment_authorized`, `confirmed`, and `cancelled`. The allowed transitions are defined by `can_transition` in `backend/app/modules/orders/domain/services/order_domain_service.py`.
+Order statuses are `pending`, `confirmed`, and `cancelled` in the current machine, with `inventory_reserved` and `payment_authorized` reserved for the MVP Target five-state lifecycle. The allowed transitions are defined by `can_transition` in `backend/app/modules/orders/domain/services.py`.
 
 | From | To | Allowed | Notes |
 |---|---|---|---|
-| `pending` | `inventory_reserved` | Yes | Triggered after stock reservation succeeds. |
-| `pending` | `cancelled` | Yes | Triggered when stock is rejected or payment is rejected. |
-| `inventory_reserved` | `payment_authorized` | Yes | Triggered after payment authorization succeeds. |
-| `inventory_reserved` | `cancelled` | Yes | Triggered when payment is rejected. |
-| `payment_authorized` | `confirmed` | Yes | Triggered after final acceptance. |
-| `payment_authorized` | `cancelled` | Yes | Triggered when final acceptance fails. |
-| `confirmed` | `pending` / `inventory_reserved` / `payment_authorized` / `cancelled` | No | Terminal state. |
-| `cancelled` | `pending` / `inventory_reserved` / `payment_authorized` / `confirmed` | No | Terminal state. |
+| `pending` | `confirmed` | Yes | Reached by the synchronous checkout when payment is authorized. |
+| `pending` | `cancelled` | Yes | Reached when stock is rejected or payment is rejected. |
+| `confirmed` | `confirmed` | Yes | Idempotent self-transition; terminal state. |
+| `cancelled` | `cancelled` | Yes | Idempotent self-transition; terminal state. |
+| `confirmed` | any other | No | Terminal state. |
+| `cancelled` | any other | No | Terminal state. |
+
+MVP Target adds the intermediate states: `pending` → `inventory_reserved` → `payment_authorized` → `confirmed`/`cancelled`, with cancellation allowed from any non-terminal state.
 
 ## Maintenance
 
 1. A code-contract change (event name, order status, bounded-context name, stack component) must update this glossary and any affected root doc in the same change.
-2. The **Current events** table reflects the per-module `domain/events/` files. The **Target events** table will match the `event_type` `Literal[...]` in `backend/app/shared/messaging/envelope.py` once the envelope is implemented.
-3. The **Order status** transitions must match `backend/app/modules/orders/domain/services/order_domain_service.py` exactly.
-4. Do not describe unwired AMQP consumers or absent shared infrastructure as live. Use `MVP Target` for capabilities that have no code in the published tree.
+2. The **Current events** table reflects the shared envelope `event_type` literal in `backend/app/shared/messaging/envelope.py`, the domain event dataclasses in `backend/app/modules/orders/domain/events.py`, and the outbox emissions from the checkout path. Keep it in sync with those files.
+3. The **Order status** transitions must match `backend/app/modules/orders/domain/services.py` exactly.
+4. Do not describe unwired AMQP consumers or absent broker wiring as live. Use `MVP Target` for capabilities that have no runtime wiring; use `Now (emission)` / `Target (forwarding)` for partial capabilities.

--- a/docs/adr/0001-use-shared-event-store.md
+++ b/docs/adr/0001-use-shared-event-store.md
@@ -2,15 +2,15 @@
 
 ## Status
 
-Accepted (MVP Target)
+Accepted (current implementation)
 
 ## Context
 
-The published Git base currently lacks a shared event store; bounded contexts use local persistence without a unified domain-events table. A single event store is needed so `orders`, `inventory`, `payments`, and `notifications` produce domain events through a common stream for order timeline audit.
+Bounded contexts need a unified domain-events stream for order timeline audit. A shared event store is implemented so `orders` (and, via checkout, the synchronous commerce path) produces domain events through a common stream: a neutral `DomainEvent` base, a single `domain_events` table, and `SqlAlchemyEventRepository` at `backend/app/shared/events/`. The orders HTTP API reads timelines from it (`GET /api/v1/orders/{order_id}/timeline`).
 
 ## Decision
 
-Accept a shared event store for the MVP Target: a neutral `DomainEvent` base, a single `domain_events` table, and `SqlAlchemyEventRepository`. Each context stores its own events through the shared repository. The implementation lives under the planned path `backend/app/shared/events/`.
+Accept a shared event store for the MVP: a neutral `DomainEvent` base, a single `domain_events` table, and `SqlAlchemyEventRepository`. Each context stores its own events through the shared repository. The implementation lives under `backend/app/shared/events/`.
 
 ## Options considered
 
@@ -29,6 +29,8 @@ Accept a shared event store for the MVP Target: a neutral `DomainEvent` base, a 
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — Patterns / Current Implementation Status matrix
 - [GLOSSARY.md](../GLOSSARY.md) — event vocabulary
-- `backend/app/shared/events/event_repository.py` (Target)
-- `backend/app/shared/events/models.py` (Target)
-- `backend/alembic/versions/` — planned migration path (Target)
+- `backend/app/shared/events/domain.py` — `DomainEvent` base
+- `backend/app/shared/events/models.py` — `domain_events` ORM model
+- `backend/app/shared/events/repository.py` — event store protocol and `TimelineEvent` read model
+- `backend/app/shared/events/event_repository.py` — `SqlAlchemyEventRepository`
+- `backend/alembic/versions/9b69790738e5_replace_order_events_with_shared_domain_events.py` — migration introducing the shared table

--- a/docs/adr/0002-use-choreography.md
+++ b/docs/adr/0002-use-choreography.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Accepted (MVP Target)
+Partially implemented
 
 ## Context
 
-The published Git base currently lacks transactional outbox, idempotency, and RabbitMQ messaging primitives. The MVP choreography wiring requires all four bounded contexts (`orders`, `inventory`, `payments`, `notifications`) to react to domain events without a central orchestrator.
+The messaging primitives this decision depends on now exist: the shared event envelope, the transactional outbox (`outbox_events` + `SqlAlchemyOutboxRepository`), and the idempotency store (`processed_events` + `ProcessedEventStore`) are implemented and exercised by the synchronous checkout path. The full choreography wiring is not delivered: there is no outbox worker/scheduler lifespan integration, no RabbitMQ publisher connection, and no AMQP consumer, so no context reacts to a published event. The current checkout is a deliberate synchronous commerce path.
 
 ## Decision
 
@@ -21,7 +21,7 @@ Use event choreography for the MVP: contexts react to events published via the t
 
 ## Consequences
 
-- **Positive**: aligns with the planned outbox and envelope; lets each context evolve independently.
+- **Positive**: aligns with the implemented outbox and envelope; lets each context evolve independently.
 - **Negative**: distributed compensations (e.g., release inventory on payment failure) are harder to trace than a saga log.
 - **Neutral**: future evolution to an orchestrated saga or hybrid is not precluded.
 
@@ -30,5 +30,7 @@ Use event choreography for the MVP: contexts react to events published via the t
 - [PRD.md](../../PRD.md) — MVP Target / coordination model
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — Patterns
 - [GLOSSARY.md](../GLOSSARY.md) — choreography, transactional outbox, idempotency
-- `backend/app/shared/messaging/outbox_repository.py` (Target)
-- `backend/app/shared/messaging/idempotency.py` (Target)
+- `backend/app/shared/messaging/outbox_repository.py` — implemented outbox repository
+- `backend/app/shared/messaging/idempotency.py` — implemented idempotency store
+- `backend/app/shared/messaging/rabbitmq_publisher.py` — publisher module exists; not wired
+- `backend/app/shared/messaging/outbox_worker.py` — worker module exists; no scheduler/lifespan integration

--- a/docs/adr/0003-use-dependency-injector.md
+++ b/docs/adr/0003-use-dependency-injector.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Accepted (MVP Target)
+Accepted (current implementation)
 
 ## Context
 
-The published Git base lacks `dependency-injector` containers and per-request session scoping. Modules use plain FastAPI routers without DI wiring (`routes/v1/router.py`). DI containers are accepted for the MVP Target to provide consistent wiring patterns and testable provider overrides across all bounded contexts.
+`dependency-injector` containers and per-request session scoping are implemented across the bounded contexts. Each context has one container, a module-level global container instance, API router wiring, and a per-request `session` override reset in `finally` (`backend/app/modules/checkout/api/routes.py` and `backend/app/modules/orders/api/routes.py`).
 
 ## Decision
 
@@ -17,20 +17,22 @@ Continue with `dependency-injector`: one container per bounded context, module-l
 | Option | Assessment |
 |--------|------------|
 | Manual constructor injection | Zero dependencies, but more boilerplate in routes and tests. |
-| dependency-injector | Planned for orders; supports scoped overrides and fits the module layout. |
+| dependency-injector | Implemented for orders, inventory, payments, notifications, and checkout; supports scoped overrides and fits the module layout. |
 | Another DI framework | Would add migration cost without clear gain over the current library. |
 
 ## Consequences
 
-- **Positive**: consistent wiring pattern across modules once implemented; request-scoped sessions keep units of work clean.
+- **Positive**: consistent wiring pattern across modules; request-scoped sessions keep units of work clean.
 - **Negative**: containers must be created for all modules before the pattern is usable across contexts.
 - **Neutral**: tests can override providers at the container boundary.
 
 ## References
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — Cross-cutting concerns / DI container strategy
-- `backend/app/modules/orders/api/container.py` (Target)
-- `backend/app/modules/orders/api/routes.py` (Target)
-- `backend/app/modules/inventory/api/container.py` (Target)
-- `backend/app/modules/payments/api/container.py` (Target)
-- `backend/app/modules/notifications/api/container.py` (Target)
+- `backend/app/modules/orders/api/container.py`
+- `backend/app/modules/orders/api/routes.py`
+- `backend/app/modules/inventory/api/container.py`
+- `backend/app/modules/payments/api/container.py`
+- `backend/app/modules/notifications/api/container.py`
+- `backend/app/modules/checkout/api/container.py`
+- `backend/app/app.py` — container `wire()` wiring

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,11 +19,11 @@ The status column is **independent of the horizon tags** in `PRD.md` and `ARCHIT
 
 | # | Title | Status |
 |---|-------|--------|
-| 0001 | [Use a shared event store](./0001-use-shared-event-store.md) | Accepted (MVP Target) |
-| 0002 | [Use event choreography](./0002-use-choreography.md) | Accepted (MVP Target) |
-| 0003 | [Use dependency-injector for DI](./0003-use-dependency-injector.md) | Accepted (MVP Target) |
+| 0001 | [Use a shared event store](./0001-use-shared-event-store.md) | Accepted (current implementation) |
+| 0002 | [Use event choreography](./0002-use-choreography.md) | Partially implemented — messaging primitives live; consumer wiring is MVP Target |
+| 0003 | [Use dependency-injector for DI](./0003-use-dependency-injector.md) | Accepted (current implementation) |
 | 0004 | [Own IAM as a bounded context](./0004-own-iam-context.md) | Accepted (MVP Target) |
-| 0005 | [Use deterministic simulated payments](./0005-use-deterministic-simulated-payments.md) | Accepted (MVP Target) |
+| 0005 | [Use deterministic simulated payments](./0005-use-deterministic-simulated-payments.md) | Accepted (current implementation) |
 
 ## Interpretation
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #45

---

## 🏷️ PR Type

- [ ] `type:bug`
- [ ] `type:feature`
- [x] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

---

## 📝 Summary

- Aligns product, architecture, design, glossary, backend, and ADR documentation with the delivered checkout implementation.
- Preserves deferred capabilities as explicit targets instead of claiming AMQP, IAM, catalog, cart, frontend, or five-state order behavior is live.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `README.md`, `backend/README.md` | Correct current routes and module layout. |
| `PRD.md`, `ARCHITECTURE.md`, `DESIGN.md`, `docs/GLOSSARY.md` | Align current-state claims, implementation status, and deferred roadmap. |
| `docs/adr/0001-0003*.md`, `docs/adr/README.md` | Sync ADR statuses and implementation notes. |

---

## 🧪 Test Plan

- [x] `cd backend && uv run python -m pytest app/tests/test_checkout_structural_regressions.py --noconftest -q` — 5 passed.
- [x] `git diff --check` — passed.
- [x] DESIGN.md validation — passed with 0 errors and pre-existing token warnings.
- [x] No source code, OpenSpec change artifacts, or verification evidence modified.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] Added exactly one `type:*` label (`type:docs`).
- [x] Documentation updated where necessary.
- [x] Commit follows Conventional Commits format.
- [x] Commit has no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

RDD remains explicitly disabled/unmanaged. This documentation PR does not run review receipts, modify RDD authority, or claim SDD archival approval.