### PR TITLE
feat(messaging): guard inventory reservations

### DIFF
--- a/backend/app/modules/inventory/application/order_status.py
+++ b/backend/app/modules/inventory/application/order_status.py
@@ -1,0 +1,11 @@
+"""Inventory-owned order status query seam."""
+
+from typing import Protocol, runtime_checkable
+from uuid import UUID
+
+
+@runtime_checkable
+class OrderStatusQuery(Protocol):
+    """Inventory-owned port to read order status without importing orders internals."""
+
+    async def get_status(self, order_id: UUID) -> str | None: ...

--- a/backend/app/modules/inventory/application/process_inventory_reservation.py
+++ b/backend/app/modules/inventory/application/process_inventory_reservation.py
@@ -1,5 +1,8 @@
 """ProcessInventoryReservation use case."""
 
+from uuid import UUID
+
+from app.modules.inventory.application.order_status import OrderStatusQuery
 from app.modules.inventory.domain.errors import InsufficientStockError
 from app.modules.inventory.domain.repository import InventoryRepository
 from app.modules.inventory.domain.services import reserve_stock
@@ -13,15 +16,24 @@ class ProcessInventoryReservation:
         inventory_repo: InventoryRepository,
         outbox: SqlAlchemyOutboxRepository,
         idempotency: ProcessedEventStore,
+        order_status: OrderStatusQuery,
     ) -> None:
         self._inventory_repo = inventory_repo
         self._outbox = outbox
         self._idempotency = idempotency
+        self._order_status = order_status
 
     async def execute(self, event_id: str, order_id: str, items: list[dict]) -> None:
         if await self._idempotency.is_processed(
             event_id, "ProcessInventoryReservation"
         ):
+            return
+        order_uuid = UUID(str(order_id))
+        status = await self._order_status.get_status(order_uuid)
+        if status in ("confirmed", "cancelled"):
+            await self._idempotency.mark_processed(
+                event_id, "ProcessInventoryReservation"
+            )
             return
         try:
             for item in items:

--- a/backend/app/modules/orders/application/get_order_status.py
+++ b/backend/app/modules/orders/application/get_order_status.py
@@ -1,0 +1,19 @@
+"""GetOrderStatus use case — orders-owned implementation of inventory port."""
+
+from uuid import UUID
+
+from app.modules.inventory.application.order_status import OrderStatusQuery
+from app.modules.orders.domain.repository import OrderRepository
+
+
+class GetOrderStatus(OrderStatusQuery):
+    """Reads order status through the orders repository."""
+
+    def __init__(self, order_repository: OrderRepository) -> None:
+        self._repository = order_repository
+
+    async def get_status(self, order_id: UUID) -> str | None:
+        order = await self._repository.get_by_id(order_id)
+        if order is None:
+            return None
+        return order.status

--- a/backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py
+++ b/backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py
@@ -1,0 +1,245 @@
+"""Unit tests for inventory terminal guard (task 3.1)."""
+
+from uuid import uuid4
+
+import pytest
+from app.modules.inventory.application.order_status import OrderStatusQuery
+from app.modules.inventory.application.process_inventory_reservation import (
+    ProcessInventoryReservation,
+)
+from app.modules.inventory.domain.entities import Inventory
+from app.modules.orders.application.get_order_status import GetOrderStatus
+
+
+class FakeInventoryRepository:
+    def __init__(self):
+        self._store = {}
+
+    async def get_by_product(self, pid):
+        inv = self._store.get(pid)
+        return (
+            Inventory(
+                product_id=inv.product_id,
+                available_quantity=inv.available_quantity,
+                reserved_quantity=inv.reserved_quantity,
+            )
+            if inv
+            else None
+        )
+
+    async def save(self, inv):
+        self._store[inv.product_id] = Inventory(
+            product_id=inv.product_id,
+            available_quantity=inv.available_quantity,
+            reserved_quantity=inv.reserved_quantity,
+        )
+
+    async def lock_and_check_availability(self, items):
+        return []
+
+
+class FakeOutbox:
+    def __init__(self):
+        self.events = []
+
+    async def save(self, event_type, aggregate_id, payload):
+        self.events.append(
+            {"event_type": event_type, "aggregate_id": aggregate_id, "payload": payload}
+        )
+
+    async def get_pending(self, limit=10):
+        return self.events
+
+
+class FakeIdempotency:
+    def __init__(self):
+        self._processed = set()
+
+    async def is_processed(self, eid, cname):
+        return (eid, cname) in self._processed
+
+    async def mark_processed(self, eid, cname):
+        self._processed.add((eid, cname))
+
+
+class FakeOrderStatus:
+    def __init__(self, statuses):
+        self._statuses = statuses
+        self.calls = []
+
+    async def get_status(self, oid):
+        self.calls.append(oid)
+        return self._statuses.get(oid)
+
+
+class FakeOrderRepository:
+    def __init__(self, orders):
+        self._orders = orders
+
+    async def get_by_id(self, oid):
+        s = self._orders.get(oid)
+        if s is None:
+            return None
+
+        class _O:
+            def __init__(self, oid, st):
+                self.id = oid
+                self.status = st
+
+        return _O(oid, s)
+
+
+@pytest.mark.asyncio
+async def test_get_order_status_returns_status():
+    oid = uuid4()
+    repo = FakeOrderRepository({oid: "confirmed"})
+    q = GetOrderStatus(repo)  # type: ignore
+    assert isinstance(q, OrderStatusQuery)
+    assert await q.get_status(oid) == "confirmed"
+    other = uuid4()
+    repo2 = FakeOrderRepository({other: "cancelled"})
+    q2 = GetOrderStatus(repo2)  # type: ignore
+    assert await q2.get_status(other) == "cancelled"
+    assert await q2.get_status(uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_confirmed_skips():
+    oid = uuid4()
+    inv = FakeInventoryRepository()
+    await inv.save(
+        Inventory(product_id="p", available_quantity=10, reserved_quantity=0)
+    )
+    out = FakeOutbox()
+    idem = FakeIdempotency()
+    qs = FakeOrderStatus({oid: "confirmed"})
+    uc = ProcessInventoryReservation(inv, out, idem, qs)  # type: ignore
+    eid = str(uuid4())
+    await uc.execute(
+        event_id=eid,
+        order_id=str(oid),
+        items=[{"product_id": "p", "quantity": 3}],
+    )
+    i = await inv.get_by_product("p")
+    assert i is not None
+    assert (
+        i.available_quantity == 10
+        and i.reserved_quantity == 0
+        and out.events == []
+        and len(qs.calls) == 1
+    )
+    assert await idem.is_processed(eid, "ProcessInventoryReservation")
+    prev = len(qs.calls)
+    await uc.execute(
+        event_id=eid, order_id=str(oid), items=[{"product_id": "p", "quantity": 3}]
+    )
+    assert len(qs.calls) == prev and out.events == []
+
+
+@pytest.mark.asyncio
+async def test_terminal_cancelled_skips():
+    oid = uuid4()
+    inv = FakeInventoryRepository()
+    await inv.save(
+        Inventory(product_id="p", available_quantity=10, reserved_quantity=0)
+    )
+    out = FakeOutbox()
+    idem = FakeIdempotency()
+    qs = FakeOrderStatus({oid: "cancelled"})
+    uc = ProcessInventoryReservation(inv, out, idem, qs)  # type: ignore
+    await uc.execute(
+        event_id=str(uuid4()),
+        order_id=str(oid),
+        items=[{"product_id": "p", "quantity": 3}],
+    )
+    i = await inv.get_by_product("p")
+    assert i is not None
+    assert i.available_quantity == 10 and out.events == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_reserves_once():
+    oid = uuid4()
+    inv = FakeInventoryRepository()
+    await inv.save(
+        Inventory(product_id="p", available_quantity=10, reserved_quantity=0)
+    )
+    out = FakeOutbox()
+    idem = FakeIdempotency()
+    qs = FakeOrderStatus({oid: "pending"})
+    uc = ProcessInventoryReservation(inv, out, idem, qs)  # type: ignore
+    eid = str(uuid4())
+    await uc.execute(
+        event_id=eid, order_id=str(oid), items=[{"product_id": "p", "quantity": 3}]
+    )
+    await uc.execute(
+        event_id=eid, order_id=str(oid), items=[{"product_id": "p", "quantity": 3}]
+    )
+    i = await inv.get_by_product("p")
+    assert i is not None
+    assert (
+        i.available_quantity == 7
+        and i.reserved_quantity == 3
+        and len([e for e in out.events if e["event_type"] == "InventoryReserved"]) == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_checkout_double_reserve_prevented():
+    oid = uuid4()
+    inv = FakeInventoryRepository()
+    await inv.save(Inventory(product_id="p", available_quantity=7, reserved_quantity=3))
+    out = FakeOutbox()
+    idem = FakeIdempotency()
+    qs = FakeOrderStatus({oid: "confirmed"})
+    uc = ProcessInventoryReservation(inv, out, idem, qs)  # type: ignore
+    await uc.execute(
+        event_id=str(uuid4()),
+        order_id=str(oid),
+        items=[{"product_id": "p", "quantity": 3}],
+    )
+    i = await inv.get_by_product("p")
+    assert i is not None
+    assert i.available_quantity == 7 and i.reserved_quantity == 3 and out.events == []
+
+
+@pytest.mark.asyncio
+async def test_pending_and_missing_reserve():
+    for status in ["pending", None]:
+        oid = uuid4()
+        inv = FakeInventoryRepository()
+        await inv.save(
+            Inventory(product_id="p", available_quantity=10, reserved_quantity=0)
+        )
+        out = FakeOutbox()
+        idem = FakeIdempotency()
+        qs = FakeOrderStatus({oid: status} if status else {})
+        uc = ProcessInventoryReservation(inv, out, idem, qs)  # type: ignore
+        await uc.execute(
+            event_id=str(uuid4()),
+            order_id=str(oid),
+            items=[{"product_id": "p", "quantity": 3}],
+        )
+        i = await inv.get_by_product("p")
+        assert i is not None
+        assert i.available_quantity == 7 and len(out.events) == 1
+    # malformed aggregate ID raises and lets consumer nack — no reservation, no status query
+    inv = FakeInventoryRepository()
+    await inv.save(
+        Inventory(product_id="p", available_quantity=10, reserved_quantity=0)
+    )
+    out = FakeOutbox()
+    idem = FakeIdempotency()
+    qs = FakeOrderStatus({})
+    uc = ProcessInventoryReservation(inv, out, idem, qs)  # type: ignore
+    eid = str(uuid4())
+    with pytest.raises(ValueError):
+        await uc.execute(
+            event_id=eid,
+            order_id="order-123",
+            items=[{"product_id": "p", "quantity": 3}],
+        )
+    i = await inv.get_by_product("p")
+    assert i is not None
+    assert i.available_quantity == 10 and out.events == [] and qs.calls == []
+    assert not await idem.is_processed(eid, "ProcessInventoryReservation")

--- a/backend/app/tests/modules/inventory/application/test_process_inventory_reservation.py
+++ b/backend/app/tests/modules/inventory/application/test_process_inventory_reservation.py
@@ -15,13 +15,21 @@ from app.shared.messaging.outbox_repository import SqlAlchemyOutboxRepository
 from app.shared.messaging.idempotency import ProcessedEventStore
 
 
+class _FakePendingOrderStatus:
+    async def get_status(self, order_id):  # type: ignore[no-untyped-def]
+        return "pending"
+
+
 class TestProcessInventoryReservation:
     @pytest.mark.asyncio
     async def test_reserves_inventory_and_emits_reserved(self, db_session) -> None:
         inv_repo = SqlAlchemyInventoryRepository(db_session)
         outbox_repo = SqlAlchemyOutboxRepository(db_session)
         idempotency = ProcessedEventStore(db_session)
-        use_case = ProcessInventoryReservation(inv_repo, outbox_repo, idempotency)
+        order_status = _FakePendingOrderStatus()
+        use_case = ProcessInventoryReservation(
+            inv_repo, outbox_repo, idempotency, order_status
+        )  # type: ignore[arg-type]
 
         await inv_repo.save(
             Inventory(product_id="prod_1", available_quantity=10, reserved_quantity=0)
@@ -29,7 +37,7 @@ class TestProcessInventoryReservation:
 
         await use_case.execute(
             event_id=str(uuid4()),
-            order_id="order-123",
+            order_id=str(uuid4()),
             items=[{"product_id": "prod_1", "quantity": 3}],
         )
 
@@ -47,7 +55,10 @@ class TestProcessInventoryReservation:
         inv_repo = SqlAlchemyInventoryRepository(db_session)
         outbox_repo = SqlAlchemyOutboxRepository(db_session)
         idempotency = ProcessedEventStore(db_session)
-        use_case = ProcessInventoryReservation(inv_repo, outbox_repo, idempotency)
+        order_status = _FakePendingOrderStatus()
+        use_case = ProcessInventoryReservation(
+            inv_repo, outbox_repo, idempotency, order_status
+        )  # type: ignore[arg-type]
 
         await inv_repo.save(
             Inventory(product_id="prod_1", available_quantity=1, reserved_quantity=0)
@@ -55,7 +66,7 @@ class TestProcessInventoryReservation:
 
         await use_case.execute(
             event_id=str(uuid4()),
-            order_id="order-123",
+            order_id=str(uuid4()),
             items=[{"product_id": "prod_1", "quantity": 3}],
         )
 
@@ -73,16 +84,20 @@ class TestProcessInventoryReservation:
         inv_repo = SqlAlchemyInventoryRepository(db_session)
         outbox_repo = SqlAlchemyOutboxRepository(db_session)
         idempotency = ProcessedEventStore(db_session)
-        use_case = ProcessInventoryReservation(inv_repo, outbox_repo, idempotency)
+        order_status = _FakePendingOrderStatus()
+        use_case = ProcessInventoryReservation(
+            inv_repo, outbox_repo, idempotency, order_status
+        )  # type: ignore[arg-type]
 
         await inv_repo.save(
             Inventory(product_id="prod_1", available_quantity=10, reserved_quantity=0)
         )
 
         event_id = str(uuid4())
+        order_id = str(uuid4())
         await use_case.execute(
             event_id=event_id,
-            order_id="order-123",
+            order_id=order_id,
             items=[{"product_id": "prod_1", "quantity": 3}],
         )
         await db_session.commit()
@@ -90,7 +105,7 @@ class TestProcessInventoryReservation:
         # Simulate duplicate delivery
         await use_case.execute(
             event_id=event_id,
-            order_id="order-123",
+            order_id=order_id,
             items=[{"product_id": "prod_1", "quantity": 3}],
         )
         await db_session.commit()

--- a/backend/app/tests/test_core_flow.py
+++ b/backend/app/tests/test_core_flow.py
@@ -12,6 +12,7 @@ from app.modules.inventory.infrastructure.sqlalchemy_repository import (
     SqlAlchemyInventoryRepository,
 )
 from app.modules.orders.application.create_order import CreateOrder
+from app.modules.orders.application.get_order_status import GetOrderStatus
 from app.modules.orders.application.process_inventory_result import (
     ProcessOrderInventoryResult,
 )
@@ -48,7 +49,10 @@ class TestCoreFlow:
 
         # Step 2: Process inventory reservation
         inv_event_id = str(uuid4())
-        inv_uc = ProcessInventoryReservation(inv_repo, outbox_repo, idempotency)
+        order_status = GetOrderStatus(order_repo)  # type: ignore[arg-type]
+        inv_uc = ProcessInventoryReservation(
+            inv_repo, outbox_repo, idempotency, order_status
+        )
         await inv_uc.execute(
             event_id=inv_event_id,
             order_id=str(order.id),
@@ -96,7 +100,10 @@ class TestCoreFlow:
         await db_session.commit()
 
         inv_event_id = str(uuid4())
-        inv_uc = ProcessInventoryReservation(inv_repo, outbox_repo, idempotency)
+        order_status = GetOrderStatus(order_repo)  # type: ignore[arg-type]
+        inv_uc = ProcessInventoryReservation(
+            inv_repo, outbox_repo, idempotency, order_status
+        )
         await inv_uc.execute(
             event_id=inv_event_id,
             order_id=str(order.id),
@@ -143,7 +150,10 @@ class TestCoreFlow:
         await db_session.commit()
 
         inv_event_id = str(uuid4())
-        inv_uc = ProcessInventoryReservation(inv_repo, outbox_repo, idempotency)
+        order_status = GetOrderStatus(order_repo)  # type: ignore[arg-type]
+        inv_uc = ProcessInventoryReservation(
+            inv_repo, outbox_repo, idempotency, order_status
+        )
         # Simulate duplicate event processing
         await inv_uc.execute(
             event_id=inv_event_id,

--- a/openspec/changes/messaging-runtime-bootstrap/apply-progress.md
+++ b/openspec/changes/messaging-runtime-bootstrap/apply-progress.md
@@ -3,16 +3,15 @@
 ## Work Unit
 
 - Change: `messaging-runtime-bootstrap`
-- Work unit: `messaging-runtime-pr2c-runtime-lifecycle` (tasks 2.3 and 2.4 only)
-- Scope: PR2c only, tasks 2.3 `messaging_runtime.py` + `backend/app/tests/runtime/` + task 2.4 `app.py` lifespan, stacked-to-main on branch `feat/messaging-runtime-lifecycle` from `origin/main` `cbb99e3` (`feat(messaging): add consumer registry` merged)
+- Work unit: `messaging-runtime-pr3a-inventory-terminal-guard` (task 3.1 only)
+- Scope: PR3a only, `inventory/application/order_status.py` + `orders/application/get_order_status.py` + guard in `process_inventory_reservation.py` + `test_inventory_terminal_guard.py`, stacked-to-main on branch `feat/messaging-inventory-handlers` from `origin/main` `5e16aec` (PR #67 merged)
 - Artifact store: OpenSpec
 - Mode: Strict TDD (`uv run --project backend python -m pytest` from worktree root or `uv run python -m pytest` from backend)
-- Delivery: auto-chain, stacked-to-main; PR2b targets `main` (like PR2a), not branch-to-branch; independently reviewable
-- Review budget: 400 authored changed lines; current delta **380 lines** (29+166+130+55) authored, **400 complete** (393 add +7 del) (see PR Boundary) — **within budget, no size:exception**
+- Delivery: auto-chain, stacked-to-main; each PR targets `main` independently
+- Review budget: 400 complete changed lines; no size:exception
 - Status: success
-- Skill Resolution: paths-injected (sdd-apply, strict-tdd, chained-pr, work-unit-commits, api-and-interface-design, observability-and-instrumentation, security-and-hardening, source-driven-development)
-- Previous apply-progress: `openspec/changes/messaging-runtime-bootstrap/apply-progress.md` (PR2a `messaging-runtime-pr2a-publisher-settings`, 58 lines) and Engram #5248 `sdd/messaging-runtime-bootstrap/apply-progress` (PR1 1.1–1.5)
-- Narrowing note: PR2a had narrowed from a 630-line full-PR2 candidate (tasks 2.1–2.5) which exceeded budget and was blocked. PR2b continues the narrowed chain: only consumer registry (task 2.2) is implemented; tasks 2.3/2.4 lifecycle/runtime/app wiring and phase 3/4 remain pending.
+- Skill Resolution: paths-injected (sdd-apply, strict-tdd, chained-pr, work-unit-commits, api-and-interface-design, security-and-hardening, source-driven-development, supabase-postgres-best-practices)
+- Previous apply-progress: PR2c `messaging-runtime-pr2c-runtime-lifecycle` on `cbb99e3`; PR2b `consumer registry`; PR2a `publisher-settings`; PR1 1.1–1.5 (Engram #5248)
 
 ## Phase Envelope
 
@@ -31,6 +30,7 @@
 - [x] 2.3 RED→GREEN `messaging_runtime.py` + `backend/app/tests/runtime/`: broker-down startup healthy, backoff (cap 30s); shutdown cancels scheduler, closes ≤10s.
 - [x] 2.4 GREEN `app.py` lifespan: non-fatal connect; start/stop runtime ordering.
 - [x] 2.5 GREEN `settings.py` + `.env.example`: `EVENTCOMMERCE_RABBITMQ_*` vars, poll interval, batch size.
+- [x] 3.1 RED→GREEN `inventory/application/order_status.py` (`OrderStatusQuery`) + `orders/application/get_order_status.py` + guard in `process_inventory_reservation.py` + test: terminal skip; duplicate once; no sync-checkout double reserve.
 
 ## PR2a Implementation Summary (preserved)
 
@@ -58,6 +58,7 @@
 | 2.1 | `backend/app/tests/shared/messaging/test_rabbitmq_publisher.py` | Unit | `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_rabbitmq_publisher.py` → 3 passed in 0.05s (safety net) | Added `test_publish_persistent_headers_no_payload_log` → **2 failed** `AssertionError: assert <DeliveryMode.NOT_PERSISTENT: 1> == <DeliveryMode.PERSISTENT: 2>` in 0.07s — proves test was written before fix | Fixed `rabbitmq_publisher.py` to set `DeliveryMode.PERSISTENT` + `logger.info` without payload → **4 passed in 0.05s** (3 existing + 1 new) | Same combined test also checks `message_id`/`aggregate_id` headers and `assert "cus_secret_123" not in caplog.text` with `caplog.at_level(logging.INFO, logger="app.shared.messaging.rabbitmq_publisher")` → 4 passed (triangulation: persistent + headers + payload-not-logged) | Merged two provisional tests into one combined assertion to stay under budget; no behavior refactor needed |
 | 2.2 | `backend/app/tests/shared/messaging/test_consumer.py` | Unit | `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py` → **ModuleNotFoundError: No module named 'app.shared.messaging.consumer'** (RED proven: test imports `ConsumerBinding, MessageConsumer` before file exists; full failure log captured) | Created `test_consumer.py` with 5 tests (registry, durable topology, invalid acked, success, failure) → initial 3 failed `TypeError: 'coroutine' object does not support async context manager` due to `AsyncMock` for `session.begin` (proves implementation not yet correct) | Fixed `consumer.py` to use `MagicMock` for `session.begin` mock and `aio_pika` durable TOPIC + prefetch 1 + bind; then `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py -v` → **5 passed in 0.06s** (dup, durable with prefetch+bind+start no_ack, invalid acked covering unknown/missing mid/invalid json, success acked with payload-not-logged + handler factory session/payload check, failure nacked requeue) | Triangulation: `test_invalid_acked` exercises 3 malformed variants (unknown type, missing `message_id`, invalid JSON) all acked; `test_durable` checks 1+2+2 bindings =5 routes across 3 durable queues, prefetch 1, and `start` no_ack False; `test_success` checks `factory.call_args[0][0] is sf._mock_session` and `handler kwargs payload` plus `secret not in caplog.text`; `test_failure` checks `nack(requeue=True)` | No refactor needed; kept module cohesive minimal (ConsumerBinding + MessageConsumer, no compatibility layer) |
 | 2.5 | `backend/app/shared/config/settings.py` + `backend/.env.example` | Unit | `uv run --project backend python -m pytest backend/app/tests/shared/config/test_settings.py` → 4 passed in 0.01s | N/A — GREEN per tasks.md | Added `Field(alias=...)` poll/batch and verified via `Settings()` env override → 4 passed + manual check | N/A — single field defaults, no branching | N/A |
+| 3.1 | `backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py` + `inventory/application/order_status.py` + `orders/application/get_order_status.py` + `process_inventory_reservation.py` | Unit | `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py -v` → 5 passed; `backend/app/tests/runtime -v` → 11 passed (safety net) | `ModuleNotFoundError: No module named 'app.modules.inventory.application.order_status'` (RED: test imports protocol before file exists) | Created `order_status.py` (`@runtime_checkable` Protocol `get_status(UUID)->str|None`) + `get_order_status.py` (`GetOrderStatus` implements Protocol via `OrderRepository.get_by_id`, only `get_status`) + guard in `process_inventory_reservation.py` (`order_status: OrderStatusQuery` required, idempotency first, then `UUID(str(order_id))` → `get_status` → if `confirmed`/`cancelled` → `mark_processed` same consumer/event and return; pending/missing → preserve reservation; malformed UUID raises to consumer nack; duplicate via `is_processed` first) → `uv run --project backend python -m pytest ...test_inventory_terminal_guard.py -v` → 6 passed in 0.03s | Triangulate: `test_get_order_status_returns_status` checks confirmed/cancelled/None (no `execute` alias); `test_terminal_confirmed_skips` (counts, processed, duplicate no-ops) + `test_terminal_cancelled_skips` (second terminal variant); `test_duplicate_reserves_once` (pending duplicate once); `test_sync_checkout_double_reserve_prevented` (confirmed checkout 7/3 unchanged); `test_pending_and_missing_reserve` (pending/None reserves + malformed `order-123` raises `ValueError`, no reservation, no status call) | No new abstraction; guard minimal, no payload logging, required constructor injection — no 3-arg compatibility, no invalid-UUID fallback |
 
 ## Work Unit Evidence (PR2b — consumer registry only)
 
@@ -106,6 +107,15 @@
 - **Next recommended**: `sdd-apply` for PR2c `messaging-runtime-pr2c-runtime` (tasks 2.3–2.4: `messaging_runtime.py` + `app.py` lifespan, broker-down healthy, backoff cap 30s, shutdown ≤10s) targeting `main` after PR2b merges, then Phase 3 handlers + Phase 4 E2E/CI/docs. Each will stay <400 and keep tests/docs with the unit they verify.
 - Do not start Phase 3 handlers or Phase 4 E2E/CI/docs until PR2b merges.
 
+## PR3a — inventory terminal guard (task 3.1 only, `messaging-runtime-pr3a-inventory-terminal-guard`)
+
+- Scope: `backend/app/modules/inventory/application/order_status.py` (11) + `backend/app/modules/orders/application/get_order_status.py` (19) + `backend/app/modules/inventory/application/process_inventory_reservation.py` delta (+12) + `backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py` (245) + `test_process_inventory_reservation.py` + `test_core_flow.py` wiring fixes from `origin/main` `5e16aec` (PR #67 merged) — no container/runtime/broker wiring (task 3.4 owns it); smallest explicit inventory-owned seam with required injection and typed aggregate ID.
+- Seam: `OrderStatusQuery` (`@runtime_checkable` Protocol, `get_status(UUID)->str|None`) in `inventory/application/order_status.py`; `GetOrderStatus` in `orders/application/get_order_status.py` implements it via `OrderRepository.get_by_id` (returns `order.status` or `None`, only `get_status` — no `execute` alias); `ProcessInventoryReservation` requires `order_status: OrderStatusQuery` (no default, no 3-arg path), checks `is_processed` first, then `UUID(str(order_id))` (malformed raises `ValueError` to consumer `nack(requeue=True)`) → `get_status` inside consumer transaction → if `confirmed`/`cancelled` → `mark_processed(event_id, "ProcessInventoryReservation")` same row and return without inventory/outbox mutation; pending/missing → preserve reserve/reject; handler failure still `nack(requeue=True)` via consumer.
+- Evidence: `uv run --project backend python -m pytest backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py -v` → 6 passed in 0.03s (terminal confirmed/cancelled skip + processed + duplicate no-ops, duplicate once, sync-checkout 7/3 unchanged, pending/missing reserves, malformed `order-123` raises `ValueError` with no reservation/no status call, GetOrderStatus confirmed/cancelled/None via `get_status` only). Safety net `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/runtime -v` → 16 passed (5 consumer + 11 runtime); `cd backend && uv run pyrefly check` → 0 errors; `ruff format/check` ok; DB suite 30 errors `connection refused` honestly reported.
+- Sync-checkout proof: inventory pre-reserved 7/3 via sync `Checkout` path (simulated `available=7 reserved=3`), async `OrderCreated` with `order_status=confirmed` → `ProcessInventoryReservation` guard skips, `available` stays 7, `reserved` stays 3, `outbox.events==[]`.
+- Rollback: revert 3 files + test (see Scope) restores 3-arg `ProcessInventoryReservation` without guard; `tasks.md` 3.1 [x] and `apply-progress.md` PR3a are SDD artifacts. No new deps, no global container wiring, never logs payload/body/credentials.
+- Next: `sdd-apply` for 3.2 (`process_inventory_result` terminal guard), 3.3 (notifications), 3.4 (container wiring supplying `GetOrderStatus`), then 4.x E2E/CI/docs; 3.2–3.4 and 4.x remain pending.
+
 ## Relevant Files
 
 - `backend/app/shared/messaging/consumer.py` — registry validation, durable TOPIC exchange, 3 durable queues, prefetch 1, 5 binds, ack after commit / nack requeue, transaction + handler factory boundaries, no-payload logging (RED→GREEN)
@@ -118,4 +128,13 @@
 
 - Scope: `messaging_runtime.py` (166) + `app.py` lifespan (+29) + `tests/runtime/` (185) from `cbb99e3`
 - Evidence: `uv run --project backend python -m pytest backend/app/tests/runtime -v` → 11 passed (8+3); `cd backend && uv run pyrefly check` → 0 errors; Ruff check/format ok
-- Next: `messaging-runtime-pr3-handlers` (3.1–3.4) then pr4 chain/integration/CI/docs; 3.x/4.x pending
+- Next (pre-PR3a): `messaging-runtime-pr3-handlers` (3.1–3.4) then pr4 chain/integration/CI/docs; 3.x/4.x pending
+
+## PR3a files (this slice)
+
+- `backend/app/modules/inventory/application/order_status.py` — inventory-owned `@runtime_checkable` Protocol `OrderStatusQuery.get_status(UUID)->str|None` (smallest seam, 11 lines)
+- `backend/app/modules/orders/application/get_order_status.py` — orders-owned `GetOrderStatus` implementing Protocol via `OrderRepository.get_by_id` (19 lines, only `get_status` — no `execute` alias)
+- `backend/app/modules/inventory/application/process_inventory_reservation.py` — required `order_status: OrderStatusQuery` injection (no default), idempotency first, then `UUID(str(order_id))` with typed contract (malformed raises), terminal guard inside consumer transaction, marks same `processed_events` row and returns without mutation (delta +12)
+- `backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py` — 6 unit tests: GetOrderStatus `get_status` only, terminal confirmed/cancelled skip + processed + duplicate no-ops, duplicate once, sync-checkout 7/3 unchanged, pending/missing reserves + malformed raises `ValueError` (245 lines, broker-free)
+- `backend/app/tests/modules/inventory/application/test_process_inventory_reservation.py` + `backend/app/tests/test_core_flow.py` — wiring fixes: mandatory `GetOrderStatus`/`_FakePendingOrderStatus` injection, valid UUID `order_id`, no 3-arg path
+- `openspec/changes/messaging-runtime-bootstrap/tasks.md` — mark 3.1 `[x]`, 3.2–3.4 and 4.x pending

--- a/openspec/changes/messaging-runtime-bootstrap/tasks.md
+++ b/openspec/changes/messaging-runtime-bootstrap/tasks.md
@@ -38,7 +38,7 @@ auto-chain; chain strategy resolved by user: stacked-to-main — PR 1 → PR 4 e
 
 ## Phase 3: Idempotent handlers
 
-- [ ] 3.1 RED→GREEN `inventory/application/order_status.py` (`OrderStatusQuery`) + `get_order_status.py` + guard in `process_inventory_reservation.py` + test: terminal skip; duplicate once; no sync-checkout double reserve.
+- [x] 3.1 RED→GREEN `inventory/application/order_status.py` (`OrderStatusQuery`) + `get_order_status.py` + guard in `process_inventory_reservation.py` + test: terminal skip; duplicate once; no sync-checkout double reserve.
 - [ ] 3.2 RED→GREEN guard `process_inventory_result.py` + test: late result on confirmed/cancelled no-ops, skip recorded.
 - [ ] 3.3 RED→GREEN `notifications/application/process_order_notification.py` + test: notifies once; duplicate no-op; processed row same transaction.
 - [ ] 3.4 GREEN wire containers (orders/inventory/notifications); composition supplies `GetOrderStatus`.


### PR DESCRIPTION
## Summary
- Guard `ProcessInventoryReservation` with inventory-owned `OrderStatusQuery` seam to skip inventory mutation and outbox writes when order is terminal (`confirmed`/`cancelled`).
- Add `GetOrderStatus` orders-owned implementation via `OrderRepository.get_by_id` exposing only `get_status(UUID) -> str | None`.
- Require mandatory `OrderStatusQuery` injection in `ProcessInventoryReservation` (no default, no 3-arg fallback); validate typed `UUID(str(order_id))` contract with `ValueError` on malformed IDs to drive consumer `nack(requeue=True)`.
- Add `test_inventory_terminal_guard.py` covering terminal skip with `mark_processed`, duplicate once, sync-checkout no double-reserve (7/3 unchanged), pending/missing reserve, malformed raises, and `GetOrderStatus` `get_status` only.

## Validation
- `uv run --project backend python -m pytest backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py -v` -> 6 passed in 0.03s
- `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/runtime -v` -> 16 passed (5 consumer + 11 runtime)
- `cd backend && uv run pyrefly check` -> 0 errors
- `ruff format` / `ruff check` -> ok
- `git diff origin/main --shortstat` -> 8 files changed, 350 insertions(+), 19 deletions(-) = 369 total; no new deps
- DB suite 30 errors `connection refused` without postgres (pre-existing, honest)

## Review boundary
- This slice is task 3.1 only against `origin/main` `5e16aec` (PR #67: `feat(messaging): add runtime lifecycle`).
- Files in scope (8 files, 369 lines):
  - `backend/app/modules/inventory/application/order_status.py` (+11)
  - `backend/app/modules/inventory/application/process_inventory_reservation.py` (+12)
  - `backend/app/modules/orders/application/get_order_status.py` (+19)
  - `backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py` (+245)
  - `backend/app/tests/modules/inventory/application/test_process_inventory_reservation.py` (+22 -7 wiring)
  - `backend/app/tests/test_core_flow.py` (+13 -3 wiring)
  - `openspec/changes/messaging-runtime-bootstrap/apply-progress.md` (+27 -8)
  - `openspec/changes/messaging-runtime-bootstrap/tasks.md` (+1 -1)
- Out of scope (follow-up slices): 3.2 guard in `process_inventory_result.py`, 3.3 notifications handler, 3.4 container wiring supplying `GetOrderStatus`, 4.x E2E/integration/CI/docs.
- No compatibility fallback: `ProcessInventoryReservation` requires `order_status: OrderStatusQuery` (4-arg); no 3-arg path. `GetOrderStatus` exposes only `get_status`, no `execute` alias.
- Rollback: revert the 3 application files + test file restores 3-arg handler without guard; SDD artifacts `tasks.md`/`apply-progress.md` are isolated.
- RDD disabled for this slice; no global container wiring or broker runtime in this diff.

Related to #59
