### PR TITLE
feat(messaging): wire runtime consumers

### DIFF
--- a/backend/app/messaging_runtime.py
+++ b/backend/app/messaging_runtime.py
@@ -2,6 +2,9 @@ import asyncio
 import logging
 import random
 from collections.abc import Awaitable, Callable
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 _CAP = 30.0
@@ -15,6 +18,103 @@ def _jittered_backoff(
     jitter: Callable[[float, float], float] = random.uniform,
 ) -> float:
     return jitter(0, min(cap, base * (2**attempt)))
+
+
+def _inventory_handler_factory(session: AsyncSession):  # type: ignore[no-untyped-def]
+    from app.modules.inventory.api.container import InventoryContainer
+    from app.modules.orders.api.container import OrdersContainer
+
+    orders_c = OrdersContainer()
+    inventory_c = InventoryContainer()
+    orders_c.session.override(session)
+    inventory_c.session.override(session)
+    get_status = orders_c.get_order_status()
+    inventory_c.order_status_query.override(get_status)
+    handler = inventory_c.process_inventory_reservation()
+
+    async def _handle(  # type: ignore[no-untyped-def]
+        *, payload: dict, event_id: str, event_type: str, aggregate_id: str
+    ) -> None:
+        if event_type != "OrderCreated":
+            raise ValueError(f"unsupported event_type: {event_type}")
+        UUID(str(aggregate_id))
+        UUID(str(event_id))
+        items = payload["items"]
+        if not isinstance(items, list):
+            raise ValueError("items must be list")
+        await handler.execute(event_id=event_id, order_id=aggregate_id, items=items)
+
+    return _handle
+
+
+def _orders_handler_factory(session: AsyncSession):  # type: ignore[no-untyped-def]
+    from app.modules.orders.api.container import OrdersContainer
+
+    orders_c = OrdersContainer()
+    orders_c.session.override(session)
+    handler = orders_c.process_order_inventory_result()
+
+    async def _handle(  # type: ignore[no-untyped-def]
+        *, payload: dict, event_id: str, event_type: str, aggregate_id: str
+    ) -> None:
+        if event_type == "InventoryReserved":
+            result = "reserved"
+        elif event_type == "InventoryRejected":
+            result = "rejected"
+        else:
+            raise ValueError(f"unsupported event_type: {event_type}")
+        order_id = UUID(str(aggregate_id))
+        UUID(str(event_id))
+        _ = payload  # payload not used beyond validation, keep exact contract
+        await handler.execute(event_id=event_id, order_id=order_id, result=result)
+
+    return _handle
+
+
+def _notifications_handler_factory(session: AsyncSession):  # type: ignore[no-untyped-def]
+    from app.modules.notifications.api.container import NotificationsContainer
+
+    notifications_c = NotificationsContainer()
+    notifications_c.session.override(session)
+    handler = notifications_c.process_order_notification()
+
+    async def _handle(  # type: ignore[no-untyped-def]
+        *, payload: dict, event_id: str, event_type: str, aggregate_id: str
+    ) -> None:
+        await handler.execute(
+            payload=payload,
+            event_id=event_id,
+            event_type=event_type,
+            aggregate_id=aggregate_id,
+        )
+
+    return _handle
+
+
+def _create_wired_consumer(session_factory, settings):  # type: ignore[no-untyped-def]
+    from app.shared.messaging.consumer import ConsumerBinding, MessageConsumer
+
+    bindings = [
+        ConsumerBinding(
+            queue="inventory.order_created",
+            event_types=("OrderCreated",),
+            consumer_name="ProcessInventoryReservation",
+            handler_factory=_inventory_handler_factory,
+        ),
+        ConsumerBinding(
+            queue="orders.inventory_result",
+            event_types=("InventoryReserved", "InventoryRejected"),
+            consumer_name="ProcessOrderInventoryResult",
+            handler_factory=_orders_handler_factory,
+        ),
+        ConsumerBinding(
+            queue="notifications.order_terminal",
+            event_types=("OrderConfirmed", "OrderCancelled"),
+            consumer_name="ProcessOrderNotification",
+            handler_factory=_notifications_handler_factory,
+        ),
+    ]
+    return MessageConsumer(settings.rabbitmq_url, bindings, session_factory)
 
 
 class MessagingRuntime:
@@ -158,9 +258,19 @@ def create_messaging_runtime(
 
         pub = publisher or RabbitMQPublisher(settings.rabbitmq_url)
         worker = OutboxWorker(session_factory, pub)
-        return MessagingRuntime(
-            pub, consumer, worker, poll, batch, sleep=sleep, jitter=jitter
+        cons = (
+            consumer
+            if consumer is not None
+            else _create_wired_consumer(session_factory, settings)
         )
+        return MessagingRuntime(
+            pub, cons, worker, poll, batch, sleep=sleep, jitter=jitter
+        )
+    cons = (
+        consumer
+        if consumer is not None
+        else _create_wired_consumer(session_factory, settings)
+    )
     return MessagingRuntime(
-        publisher, consumer, outbox_worker, poll, batch, sleep=sleep, jitter=jitter
+        publisher, cons, outbox_worker, poll, batch, sleep=sleep, jitter=jitter
     )

--- a/backend/app/modules/inventory/api/container.py
+++ b/backend/app/modules/inventory/api/container.py
@@ -1,10 +1,37 @@
 """Inventory dependency injection container."""
 
-from dependency_injector import containers
+from dependency_injector import containers, providers
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.inventory.application.order_status import OrderStatusQuery
+from app.modules.inventory.application.process_inventory_reservation import (
+    ProcessInventoryReservation,
+)
+from app.modules.inventory.infrastructure.sqlalchemy_repository import (
+    SqlAlchemyInventoryRepository,
+)
+from app.shared.messaging.idempotency import ProcessedEventStore
+from app.shared.messaging.outbox_repository import SqlAlchemyOutboxRepository
 
 
 class InventoryContainer(containers.DeclarativeContainer):
     """Inventory module container."""
+
+    session = providers.Dependency(instance_of=AsyncSession)
+
+    order_status_query = providers.Dependency(instance_of=OrderStatusQuery)
+
+    inventory_repo = providers.Factory(SqlAlchemyInventoryRepository, session=session)
+    outbox_repo = providers.Factory(SqlAlchemyOutboxRepository, session=session)
+    idempotency = providers.Factory(ProcessedEventStore, session=session)
+
+    process_inventory_reservation = providers.Factory(
+        ProcessInventoryReservation,
+        inventory_repo=inventory_repo,
+        outbox=outbox_repo,
+        idempotency=idempotency,
+        order_status=order_status_query,
+    )
 
 
 inventory_container = InventoryContainer()

--- a/backend/app/modules/notifications/api/container.py
+++ b/backend/app/modules/notifications/api/container.py
@@ -1,10 +1,35 @@
 """Notifications dependency injection container."""
 
-from dependency_injector import containers
+from dependency_injector import containers, providers
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.notifications.application.process_order_notification import (
+    ProcessOrderNotification,
+)
+from app.modules.notifications.application.send_order_notification import (
+    SendOrderNotification,
+)
+from app.modules.notifications.infrastructure.sqlalchemy_repository import (
+    SqlAlchemyNotificationRepository,
+)
+from app.shared.messaging.idempotency import ProcessedEventStore
 
 
 class NotificationsContainer(containers.DeclarativeContainer):
     """Notifications module container."""
+
+    session = providers.Dependency(instance_of=AsyncSession)
+
+    notification_repo = providers.Factory(
+        SqlAlchemyNotificationRepository, session=session
+    )
+    idempotency = providers.Factory(ProcessedEventStore, session=session)
+    notifier = providers.Factory(SendOrderNotification, repository=notification_repo)
+    process_order_notification = providers.Factory(
+        ProcessOrderNotification,
+        notifier=notifier,
+        idempotency=idempotency,
+    )
 
 
 notifications_container = NotificationsContainer()

--- a/backend/app/modules/orders/api/container.py
+++ b/backend/app/modules/orders/api/container.py
@@ -8,6 +8,7 @@ from app.modules.orders.application.confirm_order import ConfirmOrder
 from app.modules.orders.application.create_order import CreateOrder
 from app.modules.orders.application.get_order import GetOrder
 from app.modules.orders.application.get_order_timeline import GetOrderTimeline
+from app.modules.orders.application.get_order_status import GetOrderStatus
 from app.modules.orders.application.process_inventory_result import (
     ProcessOrderInventoryResult,
 )
@@ -39,6 +40,11 @@ class OrdersContainer(containers.DeclarativeContainer):
     get_order_timeline = providers.Factory(GetOrderTimeline, event_repo=event_repo)
     confirm_order = providers.Factory(ConfirmOrder, repository=order_repo)
     cancel_order = providers.Factory(CancelOrder, repository=order_repo)
+    get_order_status = providers.Factory(
+        GetOrderStatus,
+        order_repository=order_repo,
+    )
+
     process_order_inventory_result = providers.Factory(
         ProcessOrderInventoryResult,
         order_repo=order_repo,

--- a/backend/app/tests/runtime/test_container_wiring.py
+++ b/backend/app/tests/runtime/test_container_wiring.py
@@ -1,0 +1,168 @@
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.messaging_runtime import create_messaging_runtime
+from app.modules.inventory.api.container import inventory_container
+from app.modules.notifications.api.container import notifications_container
+from app.modules.orders.api.container import orders_container
+from app.shared.messaging.consumer import MessageConsumer
+
+
+class _FakeSession(AsyncSession):
+    def __init__(self):
+        pass
+
+
+class _S:
+    rabbitmq_url = "amqp://x/"
+    rabbitmq_outbox_poll_interval = 0.05
+    rabbitmq_outbox_batch_size = 10
+
+
+def _sf():
+    return _FakeSession()  # type: ignore
+
+
+def test_bindings():
+    rt = create_messaging_runtime(_S(), _sf)  # type: ignore
+    c = rt._consumer  # type: ignore
+    assert isinstance(c, MessageConsumer) and len(c._bindings) == 3
+    assert {b.queue for b in c._bindings} == {
+        "inventory.order_created",
+        "orders.inventory_result",
+        "notifications.order_terminal",
+    }
+    assert sorted(e for b in c._bindings for e in b.event_types) == sorted(
+        [
+            "OrderCreated",
+            "InventoryReserved",
+            "InventoryRejected",
+            "OrderConfirmed",
+            "OrderCancelled",
+        ]
+    )
+    assert c._session_factory is _sf
+    assert (
+        create_messaging_runtime(_S(), _sf, consumer=AsyncMock())._consumer is not None
+    )  # type: ignore
+    s1, s2 = _FakeSession(), _FakeSession()  # type: ignore
+    f = next(
+        b.handler_factory for b in c._bindings if b.queue == "inventory.order_created"
+    )
+    assert f(s1) is not f(s2)
+    with pytest.raises(Exception):
+        orders_container.get_order_status()
+
+
+@pytest.mark.asyncio
+async def test_wiring():
+    s = _FakeSession()  # type: ignore
+    from app.modules.inventory.api.container import InventoryContainer
+    from app.modules.orders.api.container import OrdersContainer
+
+    oc, ic = OrdersContainer(), InventoryContainer()
+    oc.session.override(s)
+    ic.session.override(s)
+    gs = oc.get_order_status()
+    ic.order_status_query.override(gs)
+    w = ic.process_inventory_reservation()
+    assert w._inventory_repo._session is s  # type: ignore
+    assert w._order_status._repository._session is s  # type: ignore
+    rt = create_messaging_runtime(_S(), _sf)  # type: ignore
+    inv = next(
+        b.handler_factory
+        for b in rt._consumer._bindings
+        if b.queue == "inventory.order_created"
+    )  # type: ignore
+    ord_f = next(
+        b.handler_factory
+        for b in rt._consumer._bindings
+        if b.queue == "orders.inventory_result"
+    )  # type: ignore
+    notif = next(
+        b.handler_factory
+        for b in rt._consumer._bindings
+        if b.queue == "notifications.order_terminal"
+    )  # type: ignore
+    with patch(
+        "app.modules.inventory.application.process_inventory_reservation.ProcessInventoryReservation.execute",
+        new_callable=AsyncMock,
+    ) as m:
+        h = inv(s)
+        eid, aid = str(uuid4()), str(uuid4())
+        with pytest.raises(KeyError):
+            await h(
+                payload={}, event_id=eid, event_type="OrderCreated", aggregate_id=aid
+            )
+        with pytest.raises(ValueError):
+            await h(
+                payload={"items": []},
+                event_id=eid,
+                event_type="OrderCreated",
+                aggregate_id="bad",
+            )
+        await h(
+            payload={"items": [{"product_id": "p1", "quantity": 1}]},
+            event_id=eid,
+            event_type="OrderCreated",
+            aggregate_id=aid,
+        )
+        assert m.call_args.kwargs["items"] == [{"product_id": "p1", "quantity": 1}]
+    with patch(
+        "app.modules.orders.application.process_inventory_result.ProcessOrderInventoryResult.execute",
+        new_callable=AsyncMock,
+    ) as m:
+        h = ord_f(s)
+        eid, aid = str(uuid4()), str(uuid4())
+        await h(
+            payload={}, event_id=eid, event_type="InventoryReserved", aggregate_id=aid
+        )
+        assert m.call_args.kwargs["result"] == "reserved"
+        with pytest.raises(ValueError):
+            await h(
+                payload={}, event_id=eid, event_type="OrderCreated", aggregate_id=aid
+            )
+    with patch(
+        "app.modules.notifications.application.process_order_notification.ProcessOrderNotification.execute",
+        new_callable=AsyncMock,
+    ) as m:
+        h = notif(s)
+        eid, aid = str(uuid4()), str(uuid4())
+        await h(
+            payload={"x": 1},
+            event_id=eid,
+            event_type="OrderConfirmed",
+            aggregate_id=aid,
+        )
+        m.assert_awaited_once()
+
+
+def test_containers():
+    s = _FakeSession()  # type: ignore
+    orders_container.session.override(s)
+    try:
+        from app.modules.orders.application.get_order_status import GetOrderStatus
+
+        assert isinstance(orders_container.get_order_status(), GetOrderStatus)
+    finally:
+        orders_container.session.reset_override()
+
+    class _QS:
+        async def get_status(self, oid):  # type: ignore
+            return None
+
+    fq = _QS()
+    inventory_container.session.override(s)
+    inventory_container.order_status_query.override(fq)
+    try:
+        assert inventory_container.process_inventory_reservation()._order_status is fq  # type: ignore
+    finally:
+        inventory_container.session.reset_override()
+        inventory_container.order_status_query.reset_override()
+    notifications_container.session.override(s)
+    assert (
+        notifications_container.process_order_notification()._notifier._repository._session  # type: ignore[attr-defined]
+        is s
+    )  # type: ignore
+    notifications_container.session.reset_override()

--- a/openspec/changes/messaging-runtime-bootstrap/apply-progress.md
+++ b/openspec/changes/messaging-runtime-bootstrap/apply-progress.md
@@ -3,15 +3,15 @@
 ## Work Unit
 
 - Change: `messaging-runtime-bootstrap`
-- Work unit: `messaging-runtime-pr3c-notification-handler` (task 3.3 only)
-- Scope: PR3c only, `process_order_notification.py` + `test_process_order_notification.py`, stacked-to-main on branch `feat/messaging-order-notifications` from `origin/main` `a1db18e` (#69 merged)
+- Work unit: `messaging-runtime-pr3d-container-wiring` (task 3.4 only)
+- Scope: PR3d only, containers + `messaging_runtime.py` + `test_container_wiring.py`, stacked-to-main on branch `feat/messaging-runtime-wiring` from `origin/main` `75a1125` (#70 merged)
 - Artifact store: OpenSpec
 - Mode: Strict TDD (`uv run --project backend python -m pytest`)
 - Delivery: auto-chain, stacked-to-main; each PR targets `main` independently
 - Review budget: 400 complete changed lines; no size:exception
 - Status: success
-- Skill Resolution: paths-injected (sdd-apply, strict-tdd, chained-pr, work-unit-commits, api-and-interface-design, code-simplification, review-reliability, security-and-hardening)
-- Previous apply-progress: PR3b `orders-terminal-guard` on `a1db18e`; PR3a `inventory-terminal-guard` on `2e2bfd7`; PR2c `cbb99e3`; PR2b `3d25e66`; PR1 1.1–1.5
+- Skill Resolution: paths-injected (sdd-apply, strict-tdd, chained-pr, work-unit-commits, api-and-interface-design, design-patterns, review-reliability, security-and-hardening)
+- Previous apply-progress: PR3c `notification-handler` on `75a1125`; PR3b `orders-guard` on `a1db18e`; PR3a `inventory-guard` on `2e2bfd7`; PR2c `cbb99e3`; PR2b `3d25e66`; PR1 1.1–1.5
 
 ## Phase Envelope
 
@@ -33,6 +33,7 @@
 - [x] 3.1 RED→GREEN `inventory/application/order_status.py` (`OrderStatusQuery`) + `get_order_status.py` + guard in `process_inventory_reservation.py` + test: terminal skip; duplicate once; no sync-checkout double reserve.
 - [x] 3.2 RED→GREEN guard `process_inventory_result.py` + test: late result on confirmed/cancelled no-ops, skip recorded.
 - [x] 3.3 RED→GREEN `notifications/application/process_order_notification.py` + test: notifies once; duplicate no-op; processed row same transaction.
+- [x] 3.4 GREEN wire containers (orders/inventory/notifications); composition supplies `GetOrderStatus`.
 
 ## PR2a Implementation Summary (preserved)
 
@@ -63,6 +64,7 @@
 | 3.1 | `backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py` + `inventory/application/order_status.py` + `orders/application/get_order_status.py` + `process_inventory_reservation.py` | Unit | `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py -v` → 5 passed; `backend/app/tests/runtime -v` → 11 passed (safety net) | `ModuleNotFoundError: No module named 'app.modules.inventory.application.order_status'` (RED: test imports protocol before file exists) | Created `order_status.py` (`@runtime_checkable` Protocol `get_status(UUID)->str|None`) + `get_order_status.py` (`GetOrderStatus` implements Protocol via `OrderRepository.get_by_id`, only `get_status`) + guard in `process_inventory_reservation.py` (`order_status: OrderStatusQuery` required, idempotency first, then `UUID(str(order_id))` → `get_status` → if `confirmed`/`cancelled` → `mark_processed` same consumer/event and return; pending/missing → preserve reservation; malformed UUID raises to consumer nack; duplicate via `is_processed` first) → `uv run --project backend python -m pytest ...test_inventory_terminal_guard.py -v` → 6 passed in 0.03s | Triangulate: `test_get_order_status_returns_status` checks confirmed/cancelled/None (no `execute` alias); `test_terminal_confirmed_skips` (counts, processed, duplicate no-ops) + `test_terminal_cancelled_skips` (second terminal variant); `test_duplicate_reserves_once` (pending duplicate once); `test_sync_checkout_double_reserve_prevented` (confirmed checkout 7/3 unchanged); `test_pending_and_missing_reserve` (pending/None reserves + malformed `order-123` raises `ValueError`, no reservation, no status call) | No new abstraction; guard minimal, no payload logging, required constructor injection — no 3-arg compatibility, no invalid-UUID fallback |
 | 3.2 | `backend/app/tests/modules/orders/application/test_order_result_terminal_guard.py` + `process_inventory_result.py` guard | Unit | `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/runtime -v` → 16 passed (safety net); DB `test_process_inventory_result.py` 3 errors `connection refused` honestly reported | `test_terminal_confirmed_late_reserved` → 1 == 0 `save_calls` failed; `test_terminal_skip_regardless` → `InvalidStateTransitionError: Cannot cancel order from status confirmed` — 3 failed, 2 passed proves RED before fix | Added `if order.status in ("confirmed","cancelled"): await mark_processed(event_id,"ProcessOrderInventoryResult"); return` after `is_processed`+`order-not-found` → `5 passed in 0.02s` | Triangulate: `test_terminal_cancelled_late_rejected` second terminal; `test_terminal_skip_regardless_of_result_value` proves `confirmed+rejected` and `cancelled+reserved` both no-op regardless of value (would raise without guard); `test_pending_reserved_confirms_and_pending_rejected_cancels` preserves pending→confirmed/cancelled + duplicate-once | No new abstraction; interface unchanged, no logging of payload/body/credentials, no OrderStatusQuery added |
 | 3.3 | `backend/app/tests/modules/notifications/application/test_process_order_notification.py` + `notifications/application/process_order_notification.py` | Unit | `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/runtime -v` → 16 passed (safety net); `test_process_inventory_result` 3 errors `connection refused` honestly reported | `ModuleNotFoundError: No module named 'app.modules.notifications.application.process_order_notification'` — RED proven (test imports handler before file exists; 1 error during collection) | Created `process_order_notification.py` (41 lines, `ProcessOrderNotification(notifier, idempotency)` mandatory, no defaults; `is_processed` first → `UUID(str(aggregate_id))` → event_type `OrderConfirmed`/`OrderCancelled` → channel `email` + deterministic content → `await notifier.execute` → `await mark_processed` same transaction; malformed raises `ValueError`, unknown raises `ValueError`, failure not marked) → `uv run --project backend python -m pytest ...test_process_order_notification.py -v` → **8 passed in 0.03s** (confirmed, cancelled, duplicate, duplicate-skip-without-revalidate, failure-not-marked, malformed, unknown, mandatory-deps) | Triangulate: `test_cancelled` second type, `test_duplicate_skips_without_revalidating` proves duplicate returns before UUID/event-type validation (malformed+unknown no-op), `test_notification_failure_not_marked` proves rollback boundary, `test_malformed`/`test_unknown` prove no notification and no mark; all use DB/broker-free fakes; consumer/runtime harness still 16 passed | No new abstraction; handler minimal, no payload logging, no outbox, no container wiring |
+| 3.4 | `backend/app/tests/runtime/test_container_wiring.py` + `messaging_runtime.py` + containers | Unit | `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/runtime -v` → 20 passed (safety net) | GREEN per tasks.md — composition wiring only | `test_bindings_and_fresh` + `test_session_and_adapters` → 3 passed covering 3 bindings/5 types, fresh factories, same-session GetOrderStatus, strict adapters | Inventory missing/bad/unknown, orders 2 types/unknown/bad, notifications both types — broker-free | No global override, fresh locals, exact contracts |
 
 ## Work Unit Evidence (PR2b — consumer registry only)
 
@@ -205,22 +207,44 @@
 - PostgreSQL unavailable locally — DB integration tests honestly `connection refused` (3 errors for `test_sqlalchemy_repository`, 3 for `test_process_inventory_result`) — not a regression; fake-unit harness proves handler idempotency and same-transaction boundary. Consumer/runtime harness 16 passed proves ack/nack boundary preserved.
 - Budget: complete diff 275/400 inclusive, margin preserved; no `size:exception` needed. Handler 41/0 + test 167/0 + tasks 1/1 + apply-progress 47/18 → 256 ins, 19 del → 275 complete.
 
+## Work Unit Evidence (PR3d — container wiring only)
+
+| Evidence | Required value | Result |
+|---|---|---|
+| Focused test command and exact result | Smallest command proving this unit | `uv run --project backend python -m pytest backend/app/tests/runtime/test_container_wiring.py -v` → **3 passed in 0.16s** (`test_bindings_and_fresh`, `test_session_and_adapters`, `test_providers`) |
+| Runtime harness command/scenario and exact result | Real runtime path | `create_messaging_runtime` builds `MessageConsumer` with 3 queues (`inventory.order_created:OrderCreated`, `orders.inventory_result:InventoryReserved/Rejected`, `notifications.order_terminal:OrderConfirmed/Cancelled`) + fresh local containers per `AsyncSession` where inventory `GetOrderStatus` shares same session; adapters: inventory requires `items` and rejects missing/bad/unknown, orders maps exact 2 types and rejects unknown/bad UUID, notifications delegates exact payload. Consumer/publisher/runtime harness `test_consumer` (5) + `test_rabbitmq_publisher` (4) + `test_runtime` (14 including 3 wiring) → **23 passed** proves transaction/ack boundary. |
+| Rollback boundary | Exact files/behavior | Revert `backend/app/modules/orders/api/container.py` (+6 GetOrderStatus), `backend/app/modules/inventory/api/container.py` (27→37 lines), `backend/app/modules/notifications/api/container.py` (27→35), `backend/app/messaging_runtime.py` (+110 wired consumer with 3 bindings/5 types and strict adapters), `backend/app/tests/runtime/test_container_wiring.py` (168). Restores empty containers and unwired runtime; 1.1–3.3 remain. |
+
+## Validation (post-format, pre-commit, PR3d)
+
+- `uv run --project backend ruff format` + `ruff check` → All checks passed!; `pyrefly check` → 0 errors
+- `uv run --project backend python -m pytest backend/app/tests/runtime/test_container_wiring.py -v` → 3 passed
+- `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/shared/messaging/test_rabbitmq_publisher.py backend/app/tests/runtime -v` → 23 passed (5 consumer +4 publisher +14 runtime including 3 wiring)
+
+## PR Boundary and Line Count (against `origin/main` `75a1125`)
+
+- Branch: `feat/messaging-runtime-wiring` from `75a1125` (#70)
+- Tracked diff: `git diff 75a1125 --stat` → 7 files; complete **380 insertions +20 deletions =400 complete** ≤400 (no size:exception)
+- Chain: stacked-to-main — PR3d targets `main`
+
 ## Next Steps
 
-- Next recommended: `sdd-apply` for `messaging-runtime-pr3c-notification-handler` task 3.4 (container wiring supplying `GetOrderStatus` and binding notifications handler), then pr4 chain/integration/CI/docs; keep each PR ≤400 stacked-to-main
-- Do not start 4.x until 3.4 merges
+- Next recommended: `sdd-apply` for 4.x chain/integration/CI/docs; keep each PR ≤400 stacked-to-main
+- Do not start 4.x until PR3d merges
 
-## Relevant Files (PR3c — this slice)
+## Relevant Files (PR3d — this slice)
 
-- `backend/app/modules/notifications/application/process_order_notification.py` — idempotent handler for `OrderConfirmed`/`OrderCancelled`, mandatory `SendOrderNotification`+`ProcessedEventStore`, `is_processed` first → `UUID` parse → deterministic `email`+content → `notifier.execute` → `mark_processed` same consumer transaction (RED→GREEN)
-- `backend/app/tests/modules/notifications/application/test_process_order_notification.py` — 8 unit tests: confirmed/cancelled notify + content, duplicate once, duplicate-skip-without-revalidate, failure-not-marked, malformed UUID, unknown type, mandatory deps (RED→GREEN→TRIANGULATE)
-- `openspec/changes/messaging-runtime-bootstrap/tasks.md` — mark 3.3 `[x]`, 3.4 and 4.x pending
-- `openspec/changes/messaging-runtime-bootstrap/apply-progress.md` — cumulative: 1.1-3.3 complete, 3.4/4.x pending
+- `backend/app/modules/orders/api/container.py` — adds `get_order_status` provider wiring `GetOrderStatus(order_repository=order_repo)` (GREEN)
+- `backend/app/modules/inventory/api/container.py` — mandatory `session`, `order_status_query` Dependency, `inventory_repo/outbox/idempotency` + `process_inventory_reservation` (GREEN)
+- `backend/app/modules/notifications/api/container.py` — `session`, `notification_repo/idempotency/notifier` + `process_order_notification` (GREEN)
+- `backend/app/messaging_runtime.py` — wired `MessageConsumer` 3 bindings/5 types, fresh local containers per message, exact adapters, UUID raises, no payload log, seam preserved (GREEN)
+- `backend/app/tests/runtime/test_container_wiring.py` — 3 focused tests: bindings/fresh, same-session, strict adapters + container providers (GREEN)
+- `openspec/changes/messaging-runtime-bootstrap/tasks.md` — mark 3.4 `[x]`, 4.x pending
+- `openspec/changes/messaging-runtime-bootstrap/apply-progress.md` — cumulative: 1.1–3.4 complete, 4.x pending
 
 ## Relevant Files (history preserved)
 
-- `backend/app/modules/orders/application/process_inventory_result.py` — PR3b terminal guard (6 lines)
-- `backend/app/tests/modules/orders/application/test_order_result_terminal_guard.py` — PR3b 5 tests (219)
-- `backend/app/modules/inventory/application/order_status.py` + `get_order_status.py` + `process_inventory_reservation.py` — PR3a guard + seam
-- `backend/app/shared/messaging/consumer.py` + `test_consumer.py` — PR2b registry (400)
+- `backend/app/modules/orders/application/process_inventory_result.py` — PR3b terminal guard
+- `backend/app/modules/inventory/application/order_status.py` + `get_order_status.py` — PR3a seam
+- `backend/app/shared/messaging/consumer.py` + `test_consumer.py` — PR2b registry
 - `backend/app/shared/messaging/rabbitmq_publisher.py` — PR2a persistent delivery

--- a/openspec/changes/messaging-runtime-bootstrap/tasks.md
+++ b/openspec/changes/messaging-runtime-bootstrap/tasks.md
@@ -41,7 +41,7 @@ auto-chain; chain strategy resolved by user: stacked-to-main — PR 1 → PR 4 e
 - [x] 3.1 RED→GREEN `inventory/application/order_status.py` (`OrderStatusQuery`) + `get_order_status.py` + guard in `process_inventory_reservation.py` + test: terminal skip; duplicate once; no sync-checkout double reserve.
 - [x] 3.2 RED→GREEN guard `process_inventory_result.py` + test: late result on confirmed/cancelled no-ops, skip recorded.
 - [x] 3.3 RED→GREEN `notifications/application/process_order_notification.py` + test: notifies once; duplicate no-op; processed row same transaction.
-- [ ] 3.4 GREEN wire containers (orders/inventory/notifications); composition supplies `GetOrderStatus`.
+- [x] 3.4 GREEN wire containers (orders/inventory/notifications); composition supplies `GetOrderStatus`.
 
 ## Phase 4: Chain, integration, CI, docs
 


### PR DESCRIPTION
## Summary

- Wire runtime consumers via `MessageConsumer` with 3 bindings/5 event types: `inventory.order_created:OrderCreated`, `orders.inventory_result:InventoryReserved/Rejected`, `notifications.order_terminal:OrderConfirmed/Cancelled` with fresh local containers per `AsyncSession`.
- Add `InventoryContainer`/`NotificationsContainer`/`OrdersContainer` wiring to supply `GetOrderStatus` same-session to `ProcessInventoryReservation` and expose `ProcessOrderInventoryResult`/`ProcessOrderNotification` through handler factories with strict adapters (UUID validation, `items` contract, exact event-type mapping, no payload logging).
- Add `test_container_wiring.py` (3 tests) covering bindings/fresh factories, same-session wiring, and adapter strictness for all queues.

## Validation

- `uv run --project backend python -m pytest backend/app/tests/runtime/test_container_wiring.py -v` -> 3 passed in 0.16s (`test_bindings_and_fresh`, `test_session_and_adapters`, `test_providers`)
- `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/shared/messaging/test_rabbitmq_publisher.py backend/app/tests/runtime -v` -> 23 passed (5 consumer + 4 publisher + 14 runtime including 3 wiring)
- `uv run --project backend ruff format --check .` and `uv run --project backend ruff check .` -> All checks passed; `uv run --project backend pyrefly check` -> 0 errors
- `git diff 75a1125 --shortstat` -> 7 files changed, 380 insertions(+), 20 deletions(-) = 400 complete (no size:exception)

## Review boundary

- This slice is task 3.4 only against `origin/main` `75a1125` (PR #70 `feat(messaging): process order notifications`).
- Files in scope (7 files, 400 lines):
  - `backend/app/messaging_runtime.py` (+112 -2 wired consumer with 3 bindings/5 types and strict adapters)
  - `backend/app/modules/inventory/api/container.py` (+28 -1 mandatory `session`/`order_status_query` + `process_inventory_reservation`)
  - `backend/app/modules/notifications/api/container.py` (+26 -1 `session` + `process_order_notification`)
  - `backend/app/modules/orders/api/container.py` (+6 `get_order_status` provider)
  - `backend/app/tests/runtime/test_container_wiring.py` (+168 3 focused tests)
  - `openspec/changes/messaging-runtime-bootstrap/apply-progress.md` (+39 -15 cumulative PR3d envelope, Status `success`)
  - `openspec/changes/messaging-runtime-bootstrap/tasks.md` (+1 -1 mark 3.4 `[x]`)
- Out of scope (follow-up): 4.x chain E2E, gated RabbitMQ integration, CI RabbitMQ service, docs alignment.
- No compatibility fallback: containers require injected `AsyncSession`/`OrderStatusQuery` without defaults; runtime `_create_wired_consumer` always wired unless explicit `consumer` override for tests; adapters raise `ValueError`/`KeyError` on malformed payload to drive consumer `nack(requeue=True)` per PR2b contract.
- Rollback: revert `messaging_runtime.py` wired consumer and the 3 container files restores empty containers and unwired runtime; revert `test_container_wiring.py` removes wiring tests; `tasks.md` 3.4 `[x]` and `apply-progress.md` PR3d envelope are SDD artifacts. Tasks 1.1-3.3 remain.
- Stacked-to-main: PR3d targets `main` after PR3c merges; diff shows only PR3d work unit (verified `git diff 75a1125 --stat` shows 7 files).

Related to #59
