### PR TITLE
test(messaging): cover choreography chain

### DIFF
--- a/backend/app/tests/runtime/test_chain_e2e.py
+++ b/backend/app/tests/runtime/test_chain_e2e.py
@@ -1,0 +1,344 @@
+"""Broker-free chain e2e (4.1) — fake publisher drives actual handlers."""
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.modules.inventory.application.process_inventory_reservation import (
+    ProcessInventoryReservation,
+)
+from app.modules.inventory.domain.entities import Inventory
+from app.modules.notifications.application.process_order_notification import (
+    ProcessOrderNotification,
+)
+from app.modules.notifications.application.send_order_notification import (
+    SendOrderNotification,
+)
+from app.modules.orders.application.get_order_status import GetOrderStatus
+from app.modules.orders.application.process_inventory_result import (
+    ProcessOrderInventoryResult,
+)
+from app.modules.orders.domain.entities import Order, OrderItem
+
+
+class _E:
+    def __init__(self, t: str, a: str, p: dict) -> None:
+        self.id, self.event_type, self.aggregate_id, self.payload = uuid4(), t, a, p
+
+
+class _Outbox:
+    def __init__(self) -> None:
+        self.events: list[_E] = []
+
+    async def save(self, event_type: str, aggregate_id: str, payload: dict) -> None:
+        self.events.append(_E(event_type, aggregate_id, payload))
+
+    async def get_pending(self, limit: int = 100) -> list[_E]:
+        return self.events[:limit]
+
+    async def mark_published(self, event_id: UUID) -> None:  # pragma: no cover
+        return
+
+
+class _InvRepo:
+    def __init__(self) -> None:
+        self._s: dict[str, Inventory] = {}
+
+    async def get_by_product(self, pid: str) -> Inventory | None:
+        i = self._s.get(pid)
+        return (
+            None
+            if i is None
+            else Inventory(i.product_id, i.available_quantity, i.reserved_quantity)
+        )
+
+    async def save(self, inv: Inventory) -> None:
+        self._s[inv.product_id] = Inventory(
+            inv.product_id, inv.available_quantity, inv.reserved_quantity
+        )
+
+    async def lock_and_check_availability(self, items):  # type: ignore[no-untyped-def]
+        return []
+
+
+class _OrderRepo:
+    def __init__(self, orders: dict[UUID, Order] | None = None) -> None:
+        self._o: dict[UUID, Order] = dict(orders or {})
+
+    async def get_by_id(self, oid: UUID) -> Order | None:
+        return self._o.get(oid)
+
+    async def save(self, o: Order) -> None:
+        self._o[o.id] = o
+
+
+class _EventRepo:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def add(
+        self, event_id, aggregate_type, aggregate_id, event_type, occurred_at, payload
+    ):  # type: ignore[no-untyped-def]
+        self.events.append(
+            {
+                "event_id": event_id,
+                "aggregate_type": aggregate_type,
+                "aggregate_id": aggregate_id,
+                "event_type": event_type,
+                "payload": payload,
+            }
+        )
+
+    async def get_timeline(self, aggregate_type, aggregate_id):  # type: ignore[no-untyped-def]
+        return self.events
+
+
+class _Idem:
+    def __init__(self) -> None:
+        self._p: set[tuple[str, str]] = set()
+
+    async def is_processed(self, eid: str, c: str) -> bool:
+        return (eid, c) in self._p
+
+    async def mark_processed(self, eid: str, c: str) -> None:
+        self._p.add((eid, c))
+
+
+class _NotifRepo:
+    def __init__(self) -> None:
+        self.notifications: list = []
+
+    async def save(self, n) -> None:  # type: ignore[no-untyped-def]
+        self.notifications.append(n)
+
+    async def get_by_id(self, nid):  # type: ignore[no-untyped-def]
+        return None
+
+
+class _Pub:
+    def __init__(self) -> None:
+        self.published: list[_E] = []
+
+    async def publish(self, e: _E) -> None:
+        self.published.append(e)
+
+
+def _order(oid: UUID, status: str) -> Order:
+    now = datetime.now(timezone.utc)
+    return Order(
+        id=oid,
+        customer_id="cus_1",
+        status=status,
+        cancel_reason=None,
+        created_at=now,
+        updated_at=now,
+        items=[OrderItem(product_id="p1", quantity=2)],
+    )
+
+
+def _h(order: Order, avail: int = 10, reserved: int = 0):  # type: ignore[no-untyped-def]
+    o_repo, e_repo, outbox, idem = (
+        _OrderRepo({order.id: order}),
+        _EventRepo(),
+        _Outbox(),
+        _Idem(),
+    )
+    inv = _InvRepo()
+    inv._s["p1"] = Inventory("p1", avail, reserved)
+    n_repo = _NotifRepo()
+    notifier = SendOrderNotification(n_repo)  # type: ignore[arg-type]
+    get_status = GetOrderStatus(o_repo)  # type: ignore[arg-type]
+    inv_h = ProcessInventoryReservation(inv, outbox, idem, get_status)  # type: ignore[arg-type]
+    ord_h = ProcessOrderInventoryResult(o_repo, e_repo, outbox, idem)  # type: ignore[arg-type]
+    notif_h = ProcessOrderNotification(notifier, idem)  # type: ignore[arg-type]
+    return {
+        "o_repo": o_repo,
+        "e_repo": e_repo,
+        "outbox": outbox,
+        "idem": idem,
+        "inv": inv,
+        "n_repo": n_repo,
+        "inv_h": inv_h,
+        "ord_h": ord_h,
+        "notif_h": notif_h,
+        "pub": _Pub(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_happy_chain_pending_to_confirmed_via_fake_publisher_with_duplicate_idempotent() -> (
+    None
+):
+    oid = uuid4()
+    h = _h(_order(oid, "pending"), 10, 0)
+    eid1, items = str(uuid4()), [{"product_id": "p1", "quantity": 2}]
+    await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
+    assert await h["idem"].is_processed(eid1, "ProcessInventoryReservation")
+    assert len(h["outbox"].events) == 1
+    ev1 = h["outbox"].events[0]
+    assert (
+        ev1.event_type == "InventoryReserved"
+        and ev1.aggregate_id == str(oid)
+        and ev1.payload == {"items": items}
+    )
+    await h["pub"].publish(ev1)
+    assert h["pub"].published[0].id == ev1.id and h["pub"].published[0].payload == {
+        "items": items
+    }
+    assert "aio_pika" not in str(type(h["pub"]))
+    inv = await h["inv"].get_by_product("p1")
+    assert (
+        inv is not None and inv.available_quantity == 8 and inv.reserved_quantity == 2
+    )
+    await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
+    assert len(h["outbox"].events) == 1
+    await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="reserved")
+    assert await h["idem"].is_processed(str(ev1.id), "ProcessOrderInventoryResult")
+    assert len(h["outbox"].events) == 2
+    ev2 = h["outbox"].events[1]
+    assert (
+        ev2.event_type == "OrderConfirmed"
+        and ev2.payload == {"status": "confirmed"}
+        and ev2.aggregate_id == str(oid)
+    )
+    assert (
+        len(h["e_repo"].events) == 1
+        and h["e_repo"].events[0]["event_type"] == "InventoryReserved"
+    )
+    assert (await h["o_repo"].get_by_id(oid)).status == "confirmed"  # type: ignore[union-attr]
+    await h["pub"].publish(ev2)
+    assert h["pub"].published[1].event_type == "OrderConfirmed"
+    await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="reserved")
+    assert len(h["outbox"].events) == 2 and len(h["e_repo"].events) == 1
+    await h["notif_h"].execute(
+        payload=ev2.payload,
+        event_id=str(ev2.id),
+        event_type="OrderConfirmed",
+        aggregate_id=str(oid),
+    )
+    assert await h["idem"].is_processed(str(ev2.id), "ProcessOrderNotification")
+    assert len(h["n_repo"].notifications) == 1
+    n = h["n_repo"].notifications[0]
+    assert (
+        n.channel == "email"
+        and n.content == "Your order has been confirmed"
+        and str(n.order_id) == str(oid)
+    )
+    await h["notif_h"].execute(
+        payload=ev2.payload,
+        event_id=str(ev2.id),
+        event_type="OrderConfirmed",
+        aggregate_id=str(oid),
+    )
+    assert len(h["n_repo"].notifications) == 1
+
+
+@pytest.mark.asyncio
+async def test_rejected_chain_cancelled_via_fake_publisher_with_duplicate_idempotent() -> (
+    None
+):
+    oid = uuid4()
+    h = _h(_order(oid, "pending"), 1, 0)
+    eid1, items = str(uuid4()), [{"product_id": "p1", "quantity": 2}]
+    await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
+    ev1 = h["outbox"].events[0]
+    assert (
+        ev1.event_type == "InventoryRejected"
+        and ev1.payload == {"items": items, "reason": "insufficient_stock"}
+        and ev1.aggregate_id == str(oid)
+    )
+    await h["pub"].publish(ev1)
+    assert h["pub"].published[0].event_type == "InventoryRejected"
+    inv = await h["inv"].get_by_product("p1")
+    assert inv is not None and inv.available_quantity == 1
+    await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="rejected")
+    ev2 = h["outbox"].events[1]
+    assert ev2.event_type == "OrderCancelled" and ev2.payload == {
+        "status": "cancelled",
+        "reason": "insufficient_stock",
+    }
+    assert (await h["o_repo"].get_by_id(oid)).status == "cancelled"  # type: ignore[union-attr]
+    await h["pub"].publish(ev2)
+    await h["notif_h"].execute(
+        payload=ev2.payload,
+        event_id=str(ev2.id),
+        event_type="OrderCancelled",
+        aggregate_id=str(oid),
+    )
+    assert (
+        len(h["n_repo"].notifications) == 1
+        and h["n_repo"].notifications[0].content == "Your order could not be completed"
+    )
+    assert await h["idem"].is_processed(str(ev2.id), "ProcessOrderNotification")
+    await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
+    assert len(h["outbox"].events) == 2
+    await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="rejected")
+    assert len(h["outbox"].events) == 2
+    await h["notif_h"].execute(
+        payload=ev2.payload,
+        event_id=str(ev2.id),
+        event_type="OrderCancelled",
+        aggregate_id=str(oid),
+    )
+    assert len(h["n_repo"].notifications) == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_skips_reservation_and_duplicate_prevents_double_reserve() -> (
+    None
+):
+    oid = uuid4()
+    h = _h(_order(oid, "confirmed"), 7, 3)
+    eid, items = str(uuid4()), [{"product_id": "p1", "quantity": 3}]
+    await h["inv_h"].execute(event_id=eid, order_id=str(oid), items=items)
+    inv = await h["inv"].get_by_product("p1")
+    assert (
+        inv is not None
+        and inv.available_quantity == 7
+        and inv.reserved_quantity == 3
+        and h["outbox"].events == []
+    )
+    assert await h["idem"].is_processed(eid, "ProcessInventoryReservation")
+    await h["inv_h"].execute(event_id=eid, order_id=str(oid), items=items)
+    assert (
+        h["outbox"].events == []
+        and (await h["inv"].get_by_product("p1")).available_quantity == 7
+    )  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_delivery_at_each_stage_is_idempotent() -> None:
+    oid = uuid4()
+    h = _h(_order(oid, "pending"))
+    eid1, items = str(uuid4()), [{"product_id": "p1", "quantity": 2}]
+    await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
+    ev1 = h["outbox"].events[0]
+    await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
+    await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
+    assert (
+        len(h["outbox"].events) == 1
+        and (await h["inv"].get_by_product("p1")).available_quantity == 8
+    )  # type: ignore[union-attr]
+    await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="reserved")
+    ev2 = h["outbox"].events[1]
+    await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="reserved")
+    await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="reserved")
+    assert len(h["outbox"].events) == 2 and len(h["e_repo"].events) == 1
+    await h["notif_h"].execute(
+        payload=ev2.payload,
+        event_id=str(ev2.id),
+        event_type="OrderConfirmed",
+        aggregate_id=str(oid),
+    )
+    await h["notif_h"].execute(
+        payload=ev2.payload,
+        event_id=str(ev2.id),
+        event_type="OrderConfirmed",
+        aggregate_id=str(oid),
+    )
+    assert len(h["n_repo"].notifications) == 1
+    eid_late = str(uuid4())
+    await h["ord_h"].execute(event_id=eid_late, order_id=oid, result="rejected")
+    assert (await h["o_repo"].get_by_id(oid)).status == "confirmed"  # type: ignore[union-attr]
+    assert await h["idem"].is_processed(eid_late, "ProcessOrderInventoryResult")

--- a/backend/app/tests/runtime/test_chain_e2e.py
+++ b/backend/app/tests/runtime/test_chain_e2e.py
@@ -301,10 +301,9 @@ async def test_terminal_skips_reservation_and_duplicate_prevents_double_reserve(
     )
     assert await h["idem"].is_processed(eid, "ProcessInventoryReservation")
     await h["inv_h"].execute(event_id=eid, order_id=str(oid), items=items)
-    assert (
-        h["outbox"].events == []
-        and (await h["inv"].get_by_product("p1")).available_quantity == 7
-    )  # type: ignore[union-attr]
+    inventory = await h["inv"].get_by_product("p1")
+    assert inventory is not None
+    assert h["outbox"].events == [] and inventory.available_quantity == 7
 
 
 @pytest.mark.asyncio
@@ -316,10 +315,9 @@ async def test_duplicate_delivery_at_each_stage_is_idempotent() -> None:
     ev1 = h["outbox"].events[0]
     await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
     await h["inv_h"].execute(event_id=eid1, order_id=str(oid), items=items)
-    assert (
-        len(h["outbox"].events) == 1
-        and (await h["inv"].get_by_product("p1")).available_quantity == 8
-    )  # type: ignore[union-attr]
+    inventory = await h["inv"].get_by_product("p1")
+    assert inventory is not None
+    assert len(h["outbox"].events) == 1 and inventory.available_quantity == 8
     await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="reserved")
     ev2 = h["outbox"].events[1]
     await h["ord_h"].execute(event_id=str(ev1.id), order_id=oid, result="reserved")

--- a/openspec/changes/messaging-runtime-bootstrap/apply-progress.md
+++ b/openspec/changes/messaging-runtime-bootstrap/apply-progress.md
@@ -248,3 +248,47 @@
 - `backend/app/modules/inventory/application/order_status.py` + `get_order_status.py` — PR3a seam
 - `backend/app/shared/messaging/consumer.py` + `test_consumer.py` — PR2b registry
 - `backend/app/shared/messaging/rabbitmq_publisher.py` — PR2a persistent delivery
+
+## PR4a — chain e2e (task 4.1 only, `messaging-runtime-pr4a-chain-e2e`)
+
+- Scope: `backend/app/tests/runtime/test_chain_e2e.py` (344) — fake publisher, actual handlers, order→inventory→terminal; no broker/DB; characterization e2e, not new feature
+- TDD: RED `test_chain_e2e.py` collection `ModuleNotFoundError` before file (characterization, chain already exists after 1.1–3.4); GREEN 4 passed after file; TRIANGULATE happy/rejected/duplicate/terminal/fake-publisher
+- Evidence: `uv run --project backend python -m pytest backend/app/tests/runtime/test_chain_e2e.py -v` → 4 passed in 0.04s
+
+### TDD Cycle Evidence (PR4a)
+
+| Task | Test file | Layer | Safety net | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|---|---|---|
+| 4.1 | `backend/app/tests/runtime/test_chain_e2e.py` | Unit (broker-free) | `test_consumer`+`test_runtime` 23 passed | ✅ file absent `ModuleNotFoundError` before create | ✅ 4 passed | ✅ happy/rejected/duplicate/terminal/publisher | ➖ none |
+
+### Work Unit Evidence (PR4a — chain only)
+
+| Evidence | Required value | Result |
+|---|---|---|
+| Focused test command | Smallest proving this unit | `uv run --project backend python -m pytest backend/app/tests/runtime/test_chain_e2e.py -v` → **4 passed in 0.04s** (happy, rejected, terminal, duplicate) |
+| Runtime harness | Real integration path or N/A | Fake-publisher transport drives captured outbox events between actual `ProcessInventoryReservation`→`ProcessOrderInventoryResult`→`ProcessOrderNotification` (real `SendOrderNotification`); `_Pub.publish` captures `event_type/aggregate_id/payload/id` without aio-pika/RabbitMQ/Postgres; consumer/publisher/runtime harness 23 passed proves transaction boundary preserved |
+| Rollback boundary | Exact files/behavior | Revert `backend/app/tests/runtime/test_chain_e2e.py` (344) restores no chain proof; handlers/containers/runtime remain; `tasks.md` 4.1 [x] and `apply-progress.md` PR4a are SDD artifacts |
+
+### Validation (post-format, pre-commit, PR4a)
+
+- `uv run --project backend ruff format` → 1 file left unchanged; `ruff check` → All checks passed!
+- `uv run --project backend pyrefly check` → 0 errors (CI-cwd)
+- `uv run --project backend python -m pytest backend/app/tests/runtime/test_chain_e2e.py -v` → 4 passed
+- `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/shared/messaging/test_rabbitmq_publisher.py backend/app/tests/runtime -v` → 23 passed; handler safety 19 passed
+
+### PR Boundary and Line Count (against `origin/main` `0ba9d39`)
+
+- Branch `feat/messaging-chain-e2e` from `0ba9d39` (#71); stacked-to-main, PR4a targets `main`
+- Tracked diff: `git diff 0ba9d39 --stat` → 3 files, ~374 insertions, ~1 deletion → **~375 complete** ≤400 (no size:exception, margin ~25)
+- Staged check: `git diff --cached --numstat` matches complete; no unstaged/untracked after add
+
+### Deviations / Risks / Next
+
+- None for 4.1; uses actual handlers, current contracts, minimal fakes at transport; no payload logging, no compatibility/fallback, no production change
+- Next: `sdd-apply` for 4.2–4.4 (gated integration, CI, docs) — keep each slice ≤400
+
+### Relevant Files (PR4a — this slice)
+
+- `backend/app/tests/runtime/test_chain_e2e.py` — 4 broker-free chain proofs via `_Pub` and real handlers; exact types/ids/payloads/processed keys; duplicate/terminal/publish driving
+- `openspec/changes/messaging-runtime-bootstrap/tasks.md` — mark 4.1 [x], 4.2–4.4 pending
+- `openspec/changes/messaging-runtime-bootstrap/apply-progress.md` — add PR4a evidence, preserve 1.1–3.4

--- a/openspec/changes/messaging-runtime-bootstrap/tasks.md
+++ b/openspec/changes/messaging-runtime-bootstrap/tasks.md
@@ -45,7 +45,7 @@ auto-chain; chain strategy resolved by user: stacked-to-main — PR 1 → PR 4 e
 
 ## Phase 4: Chain, integration, CI, docs
 
-- [ ] 4.1 RED→GREEN chain e2e `test_chain_e2e.py` (runtime/): fake publisher, order→inventory→terminal; no broker in default suite.
+- [x] 4.1 RED→GREEN chain e2e `test_chain_e2e.py` (runtime/): fake publisher, order→inventory→terminal; no broker in default suite.
 - [ ] 4.2 GREEN gated integration test `test_rabbitmq_integration.py` (integration/, skip unless env set): restart persistence, topology recovery, EXPLAIN evidence.
 - [ ] 4.3 GREEN `.github/workflows/api-ci.yml`: rabbitmq service, gated env, integration job.
 - [ ] 4.4 GREEN docs (after 2.4): `ARCHITECTURE.md` matrix `implemented` + evidence; GLOSSARY wiring; ADR 0002 delivered; README snapshot; no premature AMQP claims.


### PR DESCRIPTION
## Summary

- Add broker-free choreography chain proof `backend/app/tests/runtime/test_chain_e2e.py` (344 lines) via fake publisher `_Pub` driving actual handlers `ProcessInventoryReservation` → `ProcessOrderInventoryResult` → `ProcessOrderNotification` (`SendOrderNotification`) with real `GetOrderStatus` and idempotency boundaries.
- Covers 4 scenarios: happy `OrderCreated` → `InventoryReserved` → `OrderConfirmed` (email `order_confirmed`), rejected `InventoryRejected` → `OrderCancelled`, duplicate `OrderCreated` once, terminal `confirmed` checkout skip (7/3 unchanged) + `_Pub` captures exact `event_type`/`aggregate_id`/`payload`/`id` without `aio-pika`/`RabbitMQ`/`Postgres`.
- Mark SDD task `4.1` complete in `openspec/changes/messaging-runtime-bootstrap/tasks.md` and add cumulative PR4a envelope to `apply-progress.md` (44 lines, preserves 1.1–3.4).

## Validation

- `uv run --project backend python -m pytest backend/app/tests/runtime/test_chain_e2e.py -v` -> 4 passed in 0.04s (`test_happy`, `test_rejected`, `test_terminal`, `test_duplicate` + publisher driving)
- `uv run --project backend python -m pytest backend/app/tests/shared/messaging/test_consumer.py backend/app/tests/shared/messaging/test_rabbitmq_publisher.py backend/app/tests/runtime -v` -> 23 passed (5 consumer + 4 publisher + 14 runtime including 4 chain, proving ack/nack + transaction boundary preserved)
- `uv run --project backend python -m pytest backend/app/tests/modules/orders/application/test_order_result_terminal_guard.py backend/app/tests/modules/inventory/application/test_inventory_terminal_guard.py backend/app/tests/modules/notifications/application/test_process_order_notification.py -v` -> 19 passed (5 + 6 + 8) handler safety net unchanged
- `uv run --project backend ruff format backend/app/tests/runtime/test_chain_e2e.py` -> 1 file left unchanged; `uv run --project backend ruff check .` -> All checks passed; `uv run --project backend pyrefly check` -> 0 errors
- `git diff 0ba9d39 --shortstat` -> 3 files changed, 389 insertions(+), 1 deletion(-) = 390 complete (no size:exception)

## Review boundary

- This slice is task 4.1 only against `origin/main` `0ba9d39` (PR #71 `feat(messaging): wire runtime consumers`).
- Files in scope (3 files, 390 lines):
  - `backend/app/tests/runtime/test_chain_e2e.py` (+344 characterization e2e via `_Pub`, actual handlers, deterministic ids/payloads/processed keys, no payload logging)
  - `openspec/changes/messaging-runtime-bootstrap/apply-progress.md` (+44 PR4a evidence, Status `success`, TDD + Work Unit Evidence)
  - `openspec/changes/messaging-runtime-bootstrap/tasks.md` (+1 -1 mark 4.1 `[x]`, 4.2–4.4 pending)
- Out of scope (follow-up): 4.2 gated `test_rabbitmq_integration.py` (restart/topology/EXPLAIN, `EVENTCOMMERCE_RUN_RABBITMQ_INTEGRATION=1`), 4.3 `.github/workflows/api-ci.yml` RabbitMQ service + gated env, 4.4 `ARCHITECTURE.md`/GLOSSARY/ADR/docs alignment.
- No production change: pure test characterization (`_Outbox`/`_InvRepo`/`_OrderRepo`/`_NotRepo`/`_Pub` are test fakes), minimal wiring at `OrderCreated`/`InventoryResult`/`OrderConfirmed` contracts; no compatibility fallback, no global container change, never logs payload/body/credentials.
- Rollback: revert `test_chain_e2e.py` (344) restores no chain proof; revert `apply-progress.md` PR4a envelope (44) and `tasks.md` 4.1 mark (1) are SDD artifacts; handlers/containers/runtime remain (`tasks` 1.1–3.4 intact).
- Stacked-to-main: PR4a targets `main` after PR3d merges; diff shows only PR4a work unit (verified `git diff 0ba9d39 --stat` shows only 3 files, compare `git diff 0ba9d39..HEAD --numstat`).

Related to #59
